### PR TITLE
refactor library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 members = ["pio-proc", "pio-parser"]
 
 [dependencies]
+arrayvec = { version = "0.7", default_features = false }
 paste = "1.0"
 
 [dev-dependencies]

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -348,7 +348,6 @@ impl Parser {
             }
         }
 
-        let side_set = a.side_set.clone();
         let wrap = match (wrap, wrap_target) {
             (Some(wrap_source), Some(wrap_target)) => Some((
                 a.label_at_offset(wrap_source),

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -13,5 +13,6 @@ syn = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
 codespan-reporting = "0.11"
+pio = { path = ".." }
 pio-parser = { path = "../pio-parser" }
 lalrpop-util = "0.19.6"

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -11,9 +11,9 @@ pub fn pio(item: TokenStream) -> TokenStream {
     let result = match pio_parser::Parser::parse_program(&source.value()) {
         Ok(p) => {
             let origin: proc_macro2::TokenStream = format!("{:?}", p.origin).parse().unwrap();
-            let instructions: proc_macro2::TokenStream = format!(
+            let code: proc_macro2::TokenStream = format!(
                 "::std::iter::IntoIterator::into_iter([{}]).collect()",
-                p.instructions
+                p.code
                     .iter()
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
@@ -21,8 +21,12 @@ pub fn pio(item: TokenStream) -> TokenStream {
             )
             .parse()
             .unwrap();
-            let wrap: proc_macro2::TokenStream =
-                format!("::pio::Wrap {{source: {}, target: {}}}", p.wrap.source, p.wrap.target).parse().unwrap();
+            let wrap: proc_macro2::TokenStream = format!(
+                "::pio::Wrap {{source: {}, target: {}}}",
+                p.wrap.source, p.wrap.target
+            )
+            .parse()
+            .unwrap();
             let side_set: proc_macro2::TokenStream = format!(
                 "::pio::SideSet::new_from_proc_macro({}, {}, {})",
                 p.side_set.optional(),
@@ -63,7 +67,7 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 {
                     #defines_struct
                     ::pio::Program{
-                        instructions: #instructions,
+                        code: #code,
                         origin: #origin,
                         wrap: #wrap,
                         side_set: #side_set,

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -39,7 +39,7 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 let origin: proc_macro2::TokenStream =
                     format!("{:?}", program.origin).parse().unwrap();
                 let code: proc_macro2::TokenStream = format!(
-                    "::std::iter::IntoIterator::into_iter([{}]).collect()",
+                    "::core::iter::IntoIterator::into_iter([{}]).collect()",
                     program
                         .code
                         .iter()

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -4,144 +4,168 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
+/// Maximum program size supported by the macro.
+///
+/// As the program size is limited to 32 instructions on the currently available hardware as of 2021, 1024 instructions
+/// should be plenty for a while.
+const MAX_PROGRAM_SIZE: usize = 1024;
+
+struct PioMacroArgs {
+    program_size: syn::Expr,
+    _comma: syn::token::Comma,
+    source: syn::LitStr,
+}
+
+impl syn::parse::Parse for PioMacroArgs {
+    fn parse(stream: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+        Ok(Self {
+            program_size: stream.parse()?,
+            _comma: stream.parse()?,
+            source: stream.parse()?,
+        })
+    }
+}
+
 /// A macro which invokes the PIO assembler at compile time.
 #[proc_macro]
 pub fn pio(item: TokenStream) -> TokenStream {
-    let source = parse_macro_input!(item as syn::LitStr);
-    let result = match pio_parser::Parser::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::parse_program(
-        &source.value(),
-    ) {
-        Ok(pio_parser::Program {
-            program,
-            public_defines,
-        }) => {
-            let origin: proc_macro2::TokenStream = format!("{:?}", program.origin).parse().unwrap();
-            let code: proc_macro2::TokenStream = format!(
-                "::std::iter::IntoIterator::into_iter([{}]).collect()",
-                program
-                    .code
-                    .iter()
-                    .map(|v| v.to_string())
-                    .collect::<Vec<String>>()
-                    .join(",")
-            )
-            .parse()
-            .unwrap();
-            let wrap: proc_macro2::TokenStream = format!(
-                "::pio::Wrap {{source: {}, target: {}}}",
-                program.wrap.source, program.wrap.target
-            )
-            .parse()
-            .unwrap();
-            let side_set: proc_macro2::TokenStream = format!(
-                "::pio::SideSet::new_from_proc_macro({}, {}, {})",
-                program.side_set.optional(),
-                program.side_set.bits(),
-                program.side_set.pindirs()
-            )
-            .parse()
-            .unwrap();
-            let defines_struct: proc_macro2::TokenStream = format!(
-                "
+    let args = parse_macro_input!(item as PioMacroArgs);
+    let result =
+        match pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.source.value()) {
+            Ok(pio_parser::Program {
+                program,
+                public_defines,
+            }) => {
+                let origin: proc_macro2::TokenStream =
+                    format!("{:?}", program.origin).parse().unwrap();
+                let code: proc_macro2::TokenStream = format!(
+                    "::std::iter::IntoIterator::into_iter([{}]).collect()",
+                    program
+                        .code
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                )
+                .parse()
+                .unwrap();
+                let wrap: proc_macro2::TokenStream = format!(
+                    "::pio::Wrap {{source: {}, target: {}}}",
+                    program.wrap.source, program.wrap.target
+                )
+                .parse()
+                .unwrap();
+                let side_set: proc_macro2::TokenStream = format!(
+                    "::pio::SideSet::new_from_proc_macro({}, {}, {})",
+                    program.side_set.optional(),
+                    program.side_set.bits(),
+                    program.side_set.pindirs()
+                )
+                .parse()
+                .unwrap();
+                let defines_struct: proc_macro2::TokenStream = format!(
+                    "
             struct ExpandedDefines {{
                 {}
             }}
             ",
-                public_defines
-                    .keys()
-                    .map(|k| format!("{}: i32,", k))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            )
-            .parse()
-            .unwrap();
-            let defines_init: proc_macro2::TokenStream = format!(
-                "
+                    public_defines
+                        .keys()
+                        .map(|k| format!("{}: i32,", k))
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                )
+                .parse()
+                .unwrap();
+                let defines_init: proc_macro2::TokenStream = format!(
+                    "
             ExpandedDefines {{
                 {}
             }}
             ",
-                public_defines
-                    .iter()
-                    .map(|(k, v)| format!("{}: {},", k, v))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            )
-            .parse()
-            .unwrap();
-            quote! {
-                {
-                    #defines_struct
-                    ::pio_parser::Program {
-                        program: ::pio::Program::<{ ::pio::RP2040_MAX_PROGRAM_SIZE }> {
-                            code: #code,
-                            origin: #origin,
-                            wrap: #wrap,
-                            side_set: #side_set,
-                        },
-                        public_defines: #defines_init,
+                    public_defines
+                        .iter()
+                        .map(|(k, v)| format!("{}: {},", k, v))
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                )
+                .parse()
+                .unwrap();
+                let program_size = args.program_size;
+                quote! {
+                    {
+                        #defines_struct
+                        ::pio_parser::Program {
+                            program: ::pio::Program::<{ #program_size }> {
+                                code: #code,
+                                origin: #origin,
+                                wrap: #wrap,
+                                side_set: #side_set,
+                            },
+                            public_defines: #defines_init,
+                        }
                     }
                 }
             }
-        }
-        Err(e) => {
-            let files = codespan_reporting::files::SimpleFile::new("source", source.value());
+            Err(e) => {
+                let files =
+                    codespan_reporting::files::SimpleFile::new("source", args.source.value());
 
-            let (loc, messages) = match e {
-                ParseError::InvalidToken { location } => {
-                    (location..location, vec!["invalid token".to_string()])
+                let (loc, messages) = match e {
+                    ParseError::InvalidToken { location } => {
+                        (location..location, vec!["invalid token".to_string()])
+                    }
+                    ParseError::UnrecognizedEOF { location, expected } => (
+                        location..location,
+                        vec![
+                            "unrecognized eof".to_string(),
+                            format!("expected one of {}", expected.join(", ")),
+                        ],
+                    ),
+                    ParseError::UnrecognizedToken { token, expected } => (
+                        token.0..token.2,
+                        vec![
+                            format!("unexpected token: {:?}", format!("{}", token.1)),
+                            format!("expected one of {}", expected.join(", ")),
+                        ],
+                    ),
+                    ParseError::ExtraToken { token } => {
+                        (token.0..token.2, vec![format!("extra token: {}", token.1)])
+                    }
+                    ParseError::User { error } => (0..0, vec![error.to_string()]),
+                };
+
+                let diagnostic = codespan_reporting::diagnostic::Diagnostic::error()
+                    .with_message(messages[0].clone())
+                    .with_labels(
+                        messages
+                            .iter()
+                            .enumerate()
+                            .map(|(i, m)| {
+                                codespan_reporting::diagnostic::Label::new(
+                                    if i == 0 {
+                                        codespan_reporting::diagnostic::LabelStyle::Primary
+                                    } else {
+                                        codespan_reporting::diagnostic::LabelStyle::Secondary
+                                    },
+                                    (),
+                                    loc.clone(),
+                                )
+                                .with_message(m)
+                            })
+                            .collect(),
+                    );
+
+                let mut writer = codespan_reporting::term::termcolor::Buffer::ansi();
+                let config = codespan_reporting::term::Config::default();
+                codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic).unwrap();
+                let data = writer.into_inner();
+                let data = std::str::from_utf8(&data).unwrap();
+
+                quote! {
+                    compile_error!(#data)
                 }
-                ParseError::UnrecognizedEOF { location, expected } => (
-                    location..location,
-                    vec![
-                        "unrecognized eof".to_string(),
-                        format!("expected one of {}", expected.join(", ")),
-                    ],
-                ),
-                ParseError::UnrecognizedToken { token, expected } => (
-                    token.0..token.2,
-                    vec![
-                        format!("unexpected token: {:?}", format!("{}", token.1)),
-                        format!("expected one of {}", expected.join(", ")),
-                    ],
-                ),
-                ParseError::ExtraToken { token } => {
-                    (token.0..token.2, vec![format!("extra token: {}", token.1)])
-                }
-                ParseError::User { error } => (0..0, vec![error.to_string()]),
-            };
-
-            let diagnostic = codespan_reporting::diagnostic::Diagnostic::error()
-                .with_message(messages[0].clone())
-                .with_labels(
-                    messages
-                        .iter()
-                        .enumerate()
-                        .map(|(i, m)| {
-                            codespan_reporting::diagnostic::Label::new(
-                                if i == 0 {
-                                    codespan_reporting::diagnostic::LabelStyle::Primary
-                                } else {
-                                    codespan_reporting::diagnostic::LabelStyle::Secondary
-                                },
-                                (),
-                                loc.clone(),
-                            )
-                            .with_message(m)
-                        })
-                        .collect(),
-                );
-
-            let mut writer = codespan_reporting::term::termcolor::Buffer::ansi();
-            let config = codespan_reporting::term::Config::default();
-            codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic).unwrap();
-            let data = writer.into_inner();
-            let data = std::str::from_utf8(&data).unwrap();
-
-            quote! {
-                compile_error!(#data)
             }
-        }
-    };
+        };
     TokenStream::from(result)
 }

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -8,7 +8,9 @@ use syn::parse_macro_input;
 #[proc_macro]
 pub fn pio(item: TokenStream) -> TokenStream {
     let source = parse_macro_input!(item as syn::LitStr);
-    let result = match pio_parser::Parser::parse_program(&source.value()) {
+    let result = match pio_parser::Parser::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::parse_program(
+        &source.value(),
+    ) {
         Ok(pio_parser::Program {
             program,
             public_defines,
@@ -71,7 +73,7 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 {
                     #defines_struct
                     ::pio_parser::Program {
-                        program: ::pio::Program {
+                        program: ::pio::Program::<{ ::pio::RP2040_MAX_PROGRAM_SIZE }> {
                             code: #code,
                             origin: #origin,
                             wrap: #wrap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,7 @@ impl Assembler {
         };
 
         Program {
-            instructions: self.instructions.iter().map(|i| i.encode(&self)).collect(),
+            code: self.instructions.iter().map(|i| i.encode(&self)).collect(),
             origin: None,
             wrap,
             side_set: self.side_set,
@@ -624,8 +624,8 @@ pub struct Wrap {
 
 #[derive(Debug)]
 pub struct Program<PublicDefines> {
-    /// Assembled instructions.
-    pub instructions: ArrayVec<u16, MAX_PROGRAM_SIZE>,
+    /// Assembled program code.
+    pub code: ArrayVec<u16, MAX_PROGRAM_SIZE>,
     /// Offset at which the program must be loaded.
     ///
     /// Most often 0 if defined. This might be needed when using data based JMPs.
@@ -648,7 +648,7 @@ impl<P> Program<P> {
         public_defines: PublicDefines,
     ) -> Program<PublicDefines> {
         Program {
-            instructions: self.instructions,
+            code: self.code,
             origin: self.origin,
             wrap: self.wrap,
             side_set: self.side_set,
@@ -668,7 +668,7 @@ fn test_jump_1() {
     a.jmp(JmpCondition::Always, &mut l);
 
     assert_eq!(
-        a.assemble(None).instructions.as_slice(),
+        a.assemble(None).code.as_slice(),
         &[
             0b111_00000_001_00000, // SET X 0
             // L:
@@ -692,7 +692,7 @@ fn test_jump_2() {
     a.set(SetDestination::Y, 1);
 
     assert_eq!(
-        a.assemble(None).instructions.as_slice(),
+        a.assemble(None).code.as_slice(),
         &[
             // TOP:
             0b111_00000_010_00000, // SET Y 0
@@ -753,7 +753,7 @@ macro_rules! instr_test {
                 a.$name(
                     $( $v ),*
                 );
-                let a = a.assemble(None).instructions[0];
+                let a = a.assemble(None).code[0];
                 let b = $b;
                 if a != b {
                     panic!("assertion failure: (left == right)\nleft:  {:#016b}\nright: {:#016b}", a, b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! a.out(pio::OutDestination::PINS, 1);
 //! a.jmp(pio::JmpCondition::Always, &mut loop_label);
 //!
-//! let program = a.assemble(None);
+//! let program = a.assemble_program();
 //! ```
 //!
 //! ## Wrapping
@@ -30,7 +30,7 @@
 //! a.out(pio::OutDestination::PINS, 1);
 //! a.bind(&mut wrap_source);
 //!
-//! let program = a.assemble(Some((wrap_source, wrap_target)));
+//! let program = a.assemble_with_wrap(wrap_source, wrap_target);
 //! ```
 
 #![no_std]
@@ -38,12 +38,12 @@
 #![allow(clippy::unusual_byte_groupings)]
 #![allow(clippy::upper_case_acronyms)]
 
-use arrayvec::ArrayVec;
+pub use arrayvec::ArrayVec;
 
 /// Maximum program size in bytes.
 ///
 /// See Chapter 3, Figure 38 for reference of the value.
-const MAX_PROGRAM_SIZE: usize = 32;
+pub const MAX_PROGRAM_SIZE: usize = 32;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
@@ -402,41 +402,47 @@ impl Assembler {
     }
 
     /// Assemble the program into PIO instructions.
-    ///
-    /// Takes optional pair of labels controlling the wrapping. The first label is the source (top) of the wrap while
-    /// the second label is the target (bottom) of the wrap.
-    ///
-    /// If no labels are provided, the program wraps from after the last instruction to the top of the program.
-    pub fn assemble(self, wrap: Option<(Label, Label)>) -> Program<()> {
-        let wrap = if let Some((source, target)) = wrap {
-            let source = match source.state {
-                LabelState::Bound(addr) => addr,
-                LabelState::Unbound(_) => panic!("source label can't be unbound"),
-            };
-            let target = match target.state {
-                LabelState::Bound(addr) => addr,
-                LabelState::Unbound(_) => panic!("target label can't be unbound"),
-            };
+    pub fn assemble(self) -> ArrayVec<u16, MAX_PROGRAM_SIZE> {
+        self.instructions.iter().map(|i| i.encode(&self)).collect()
+    }
 
-            Wrap {
-                // We need to subtract one here as the label is positioned _after_ the instruction we want to wrap from,
-                // but the hardware wants the index of that instruction.
-                source: source - 1,
-                target,
-            }
-        } else {
-            Wrap {
-                source: (self.instructions.len() - 1) as u8,
-                target: 0,
-            }
+    /// Assemble the program into [`Program`].
+    ///
+    /// The program contains the instructions and side-set info set. You can directly compile into a program with
+    /// correct wrapping with [`Self::assemble_with_wrap`], or you can set the wrapping after the compilation with
+    /// [`Program::set_wrap`].
+    pub fn assemble_program(self) -> Program {
+        let side_set = self.side_set;
+        let code = self.assemble();
+        let wrap = Wrap {
+            source: (code.len() - 1) as u8,
+            target: 0,
         };
 
         Program {
-            code: self.instructions.iter().map(|i| i.encode(&self)).collect(),
+            code,
             origin: None,
+            side_set,
             wrap,
-            side_set: self.side_set,
-            public_defines: (),
+        }
+    }
+
+    /// Assemble the program into [`Program`] with wrapping.
+    ///
+    /// Takes pair of labels controlling the wrapping. The first label is the source (top) of the wrap while the second
+    /// label is the target (bottom) of the wrap. The source label should be positioned _after_ the instruction from
+    /// which the wrapping happens.
+    pub fn assemble_with_wrap(self, source: Label, target: Label) -> Program {
+        let source = self.label_offset(&source) - 1;
+        let target = self.label_offset(&target);
+        self.assemble_program().set_wrap(Wrap { source, target })
+    }
+
+    /// Get the offset of a label in the program.
+    pub fn label_offset(&self, label: &Label) -> u8 {
+        match &label.state {
+            &LabelState::Bound(offset) => offset,
+            &LabelState::Unbound(_) => panic!("can't get offset for unbound label"),
         }
     }
 }
@@ -622,7 +628,7 @@ pub struct Wrap {
 
 /// Program ready to be executed by PIO hardware.
 #[derive(Debug)]
-pub struct Program<PublicDefines> {
+pub struct Program {
     /// Assembled program code.
     pub code: ArrayVec<u16, MAX_PROGRAM_SIZE>,
     /// Offset at which the program must be loaded.
@@ -633,26 +639,21 @@ pub struct Program<PublicDefines> {
     pub wrap: Wrap,
     /// Side-set info for this program.
     pub side_set: SideSet,
-    /// Public defines for the program.
-    pub public_defines: PublicDefines,
 }
 
-impl<P> Program<P> {
+impl Program {
+    /// Set the program loading location.
+    ///
+    /// If `None`, the program can be loaded at any location in the instruction memory.
     pub fn set_origin(self, origin: Option<u8>) -> Self {
         Self { origin, ..self }
     }
 
-    pub fn set_public_defines<PublicDefines>(
-        self,
-        public_defines: PublicDefines,
-    ) -> Program<PublicDefines> {
-        Program {
-            code: self.code,
-            origin: self.origin,
-            wrap: self.wrap,
-            side_set: self.side_set,
-            public_defines,
-        }
+    /// Set the wrapping of the program.
+    pub fn set_wrap(self, wrap: Wrap) -> Self {
+        assert!((wrap.source as usize) < self.code.len());
+        assert!((wrap.target as usize) < self.code.len());
+        Self { wrap, ..self }
     }
 }
 
@@ -667,7 +668,7 @@ fn test_jump_1() {
     a.jmp(JmpCondition::Always, &mut l);
 
     assert_eq!(
-        a.assemble(None).code.as_slice(),
+        a.assemble().as_slice(),
         &[
             0b111_00000_001_00000, // SET X 0
             // L:
@@ -691,7 +692,7 @@ fn test_jump_2() {
     a.set(SetDestination::Y, 1);
 
     assert_eq!(
-        a.assemble(None).code.as_slice(),
+        a.assemble().as_slice(),
         &[
             // TOP:
             0b111_00000_010_00000, // SET Y 0
@@ -704,7 +705,7 @@ fn test_jump_2() {
 }
 
 #[test]
-fn test_wrap() {
+fn test_assemble_with_wrap() {
     let mut a = Assembler::new();
 
     let mut source = a.label();
@@ -718,7 +719,7 @@ fn test_wrap() {
     a.jmp(JmpCondition::Always, &mut target);
 
     assert_eq!(
-        a.assemble(Some((source, target))).wrap,
+        a.assemble_with_wrap(source, target).wrap,
         Wrap {
             source: 2,
             target: 1,
@@ -727,7 +728,7 @@ fn test_wrap() {
 }
 
 #[test]
-fn test_default_wrap() {
+fn test_assemble_program_default_wrap() {
     let mut a = Assembler::new();
 
     a.set(SetDestination::PINDIRS, 0);
@@ -735,7 +736,7 @@ fn test_default_wrap() {
     a.push(false, false);
 
     assert_eq!(
-        a.assemble(None).wrap,
+        a.assemble_program().wrap,
         Wrap {
             source: 2,
             target: 0,
@@ -752,7 +753,7 @@ macro_rules! instr_test {
                 a.$name(
                     $( $v ),*
                 );
-                let a = a.assemble(None).code[0];
+                let a = a.assemble()[0];
                 let b = $b;
                 if a != b {
                     panic!("assertion failure: (left == right)\nleft:  {:#016b}\nright: {:#016b}", a, b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,16 +621,15 @@ pub struct Wrap {
 }
 
 /// Program ready to be executed by PIO hardware.
-
 #[derive(Debug)]
 pub struct Program<PublicDefines> {
     /// Assembled program code.
     pub code: ArrayVec<u16, MAX_PROGRAM_SIZE>,
     /// Offset at which the program must be loaded.
     ///
-    /// Most often 0 if defined. This might be needed when using data based JMPs.
+    /// Most often 0 if defined. This might be needed when using data based `JMP`s.
     pub origin: Option<u8>,
-    /// Wrapping behavior of this program.
+    /// Wrapping behavior for this program.
     pub wrap: Wrap,
     /// Side-set info for this program.
     pub side_set: SideSet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,8 +441,8 @@ impl<const PROGRAM_SIZE: usize> Assembler<PROGRAM_SIZE> {
     /// Get the offset of a label in the program.
     pub fn label_offset(&self, label: &Label) -> u8 {
         match &label.state {
-            &LabelState::Bound(offset) => offset,
-            &LabelState::Unbound(_) => panic!("can't get offset for unbound label"),
+            LabelState::Bound(offset) => *offset,
+            LabelState::Unbound(_) => panic!("can't get offset for unbound label"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! PIO
+//! # Programmable Input/Output
 //!
 //! ```rust
 //! // Repeatedly get one word of data from the TX FIFO, stalling when
@@ -17,14 +17,14 @@
 //! let program = a.assemble(None);
 //! ```
 //!
-//! # Wrapping
+//! ## Wrapping
 //! ```rust
 //! let mut a = pio::Assembler::new();
 //!
 //! let mut wrap_source = a.label();
 //! let mut wrap_target = a.label();
 //!
-//! // Initialize pins only once
+//! // Initialize pin direction only once
 //! a.set(pio::SetDestination::PINDIRS, 1);
 //! a.bind(&mut wrap_target);
 //! a.out(pio::OutDestination::PINS, 1);
@@ -262,6 +262,7 @@ impl InstructionOperands {
     }
 }
 
+/// A PIO instruction.
 #[derive(Debug)]
 pub struct Instruction {
     pub operands: InstructionOperands,

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -5,7 +5,7 @@ extern crate pretty_assertions;
 fn test(test: &str) {
     let path = std::path::PathBuf::from(test);
     let program_source = std::fs::read_to_string(&path).unwrap();
-    let programs = pio_parser::Program::parse_file(&program_source).unwrap();
+    let programs = pio_parser::Parser::parse_file(&program_source).unwrap();
 
     let mut hex_path = path;
     hex_path.set_extension("hex");
@@ -24,7 +24,7 @@ fn test(test: &str) {
         }
 
         for (i, h) in hex_programs.iter().enumerate() {
-            assert_eq!(programs[i].code(), h);
+            assert_eq!(&*programs[i].instructions, h);
         }
     }
 }

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -24,7 +24,7 @@ fn test(test: &str) {
         }
 
         for (i, h) in hex_programs.iter().enumerate() {
-            assert_eq!(&*programs[i].instructions, h);
+            assert_eq!(&*programs[i].code, h);
         }
     }
 }

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -5,7 +5,9 @@ extern crate pretty_assertions;
 fn test(test: &str) {
     let path = std::path::PathBuf::from(test);
     let program_source = std::fs::read_to_string(&path).unwrap();
-    let programs = pio_parser::Parser::parse_file(&program_source).unwrap();
+    let programs =
+        pio_parser::Parser::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::parse_file(&program_source)
+            .unwrap();
 
     let mut hex_path = path;
     hex_path.set_extension("hex");

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -24,7 +24,7 @@ fn test(test: &str) {
         }
 
         for (i, h) in hex_programs.iter().enumerate() {
-            assert_eq!(&*programs[i].code, h);
+            assert_eq!(&*programs[i].program.code, h);
         }
     }
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -6,10 +6,10 @@ fn test_pio_proc() {
         jmp label
     "
     );
-    assert_eq!(p.origin, None);
-    assert_eq!(&*p.code, &[0u16]);
+    assert_eq!(p.program.origin, None);
+    assert_eq!(&*p.program.code, &[0u16]);
     assert_eq!(
-        p.wrap,
+        p.program.wrap,
         pio::Wrap {
             source: 0,
             target: 0
@@ -30,10 +30,10 @@ fn test_pio_proc2() {
     .define public owo label + 2
     "
     );
-    assert_eq!(p.origin, Some(5));
-    assert_eq!(&*p.code, &[0, 0]);
+    assert_eq!(p.program.origin, Some(5));
+    assert_eq!(&*p.program.code, &[0, 0]);
     assert_eq!(
-        p.wrap,
+        p.program.wrap,
         pio::Wrap {
             source: 0,
             target: 0

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test_pio_proc() {
     let p = pio_proc::pio!(
+        1,
         "
     label:
         jmp label
@@ -20,6 +21,7 @@ fn test_pio_proc() {
 #[test]
 fn test_pio_proc2() {
     let p = pio_proc::pio!(
+        32,
         "
     .origin 5
     public label:
@@ -41,4 +43,17 @@ fn test_pio_proc2() {
     );
     assert_eq!(p.public_defines.label, 0);
     assert_eq!(p.public_defines.owo, 2);
+}
+
+#[test]
+fn test_pio_proc_size() {
+    // Inline constant size
+    pio_proc::pio!(32, "label:\njmp label\n");
+    // Constant variable
+    const PROGRAM_SIZE: usize = 32;
+    pio_proc::pio!(PROGRAM_SIZE, "label:\njmp label\n");
+    // Expression
+    pio_proc::pio!(10 + 20, "label:\njmp label\n");
+    // Constant from another crate
+    pio_proc::pio!(pio::RP2040_MAX_PROGRAM_SIZE, "label:\njmp label\n");
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -6,9 +6,15 @@ fn test_pio_proc() {
         jmp label
     "
     );
-    assert_eq!(p.origin(), None);
-    assert_eq!(p.code(), &[0]);
-    assert_eq!(p.wrap(), (0, 0));
+    assert_eq!(p.origin, None);
+    assert_eq!(&*p.instructions, &[0u16]);
+    assert_eq!(
+        p.wrap,
+        pio::Wrap {
+            source: 0,
+            target: 0
+        }
+    );
 }
 
 #[test]
@@ -24,9 +30,15 @@ fn test_pio_proc2() {
     .define public owo label + 2
     "
     );
-    assert_eq!(p.origin(), Some(5));
-    assert_eq!(p.code(), &[0, 0]);
-    assert_eq!(p.wrap(), (0, 0));
-    assert_eq!(p.public_defines().label, 0);
-    assert_eq!(p.public_defines().owo, 2);
+    assert_eq!(p.origin, Some(5));
+    assert_eq!(&*p.instructions, &[0, 0]);
+    assert_eq!(
+        p.wrap,
+        pio::Wrap {
+            source: 0,
+            target: 0
+        }
+    );
+    assert_eq!(p.public_defines.label, 0);
+    assert_eq!(p.public_defines.owo, 2);
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -7,7 +7,7 @@ fn test_pio_proc() {
     "
     );
     assert_eq!(p.origin, None);
-    assert_eq!(&*p.instructions, &[0u16]);
+    assert_eq!(&*p.code, &[0u16]);
     assert_eq!(
         p.wrap,
         pio::Wrap {
@@ -31,7 +31,7 @@ fn test_pio_proc2() {
     "
     );
     assert_eq!(p.origin, Some(5));
-    assert_eq!(&*p.instructions, &[0, 0]);
+    assert_eq!(&*p.code, &[0, 0]);
     assert_eq!(
         p.wrap,
         pio::Wrap {


### PR DESCRIPTION
This makes it possible to assemble directly into one struct with all necessary info for execution.

This PR also removes dependency on `alloc` from `pio` to make it even easier to use on embedded hardware. [`ArrayVec`](https://docs.rs/arrayvec/0.7.1/arrayvec/struct.ArrayVec.html) is used instead.

This PR is needed for [`rp-hal#74`](https://github.com/rp-rs/rp-hal/pull/74) and was written with the needs of `rp-hal` in mind.