### PR TITLE
Fix decoding of side_set values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,9 +403,15 @@ impl Instruction {
             let data = ((instruction >> 8) & 0b11111) as u8;
 
             let delay = data & ((1 << (5 - side_set.bits)) - 1);
-            let side_set = match data >> (5 - side_set.bits) {
-                0 => None,
-                s => Some(s & if side_set.opt { 0b01111 } else { 0b11111 }),
+
+            let has_side_set = side_set.bits > 0 && (!side_set.opt || data & 0b10000 > 0);
+            let side_set_data =
+                (data & if side_set.opt { 0b01111 } else { 0b11111 }) >> (5 - side_set.bits);
+
+            let side_set = if has_side_set {
+                Some(side_set_data)
+            } else {
+                None
             };
 
             Instruction {


### PR DESCRIPTION
While trying to use ws2812-pio, I got an error `ERROR panicked at 'instruction requires 'side' set', /home/jan/.cargo/git/checkouts/pio-rs-2d5cbd3dcca73fa9/ffcd426/src/lib.rs:390:13`.

It turned out that this was caused by a bug in the decoding of side_set values.