### PR TITLE
Fix pio_proc::pio!() in no-std programs.

### DIFF
--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -4,7 +4,7 @@
 
 use pio::{
     InSource, Instruction, InstructionOperands, JmpCondition, MovDestination, MovOperation,
-    MovSource, OutDestination, SetDestination, WaitSource,
+    MovSource, OutDestination, ProgramWithDefines, SetDestination, WaitSource,
 };
 
 use std::collections::HashMap;
@@ -241,7 +241,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
     /// separated by `.program` directives.
     pub fn parse_file(
         source: &str,
-    ) -> Result<Vec<Program<HashMap<String, i32>, PROGRAM_SIZE>>, ParseError> {
+    ) -> Result<Vec<ProgramWithDefines<HashMap<String, i32>, PROGRAM_SIZE>>, ParseError> {
         match parser::FileParser::new().parse(source) {
             Ok(f) => {
                 let mut state = FileState::default();
@@ -271,7 +271,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
     /// Parse a single PIO program, without the `.program` directive.
     pub fn parse_program(
         source: &str,
-    ) -> Result<Program<HashMap<String, i32>, PROGRAM_SIZE>, ParseError> {
+    ) -> Result<ProgramWithDefines<HashMap<String, i32>, PROGRAM_SIZE>, ParseError> {
         match parser::ProgramParser::new().parse(source) {
             Ok(p) => Ok(Parser::process(&p, &mut FileState::default())),
             Err(e) => Err(e),
@@ -281,7 +281,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
     fn process(
         p: &[Line],
         file_state: &mut FileState,
-    ) -> Program<HashMap<String, i32>, PROGRAM_SIZE> {
+    ) -> ProgramWithDefines<HashMap<String, i32>, PROGRAM_SIZE> {
         let mut state = ProgramState::new(file_state);
 
         // first pass
@@ -368,19 +368,11 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
             ),
         };
 
-        Program {
+        ProgramWithDefines {
             program,
             public_defines: state.public_defines(),
         }
     }
-}
-
-/// Parsed program with defines.
-pub struct Program<PublicDefines, const PROGRAM_SIZE: usize> {
-    /// The compiled program.
-    pub program: pio::Program<PROGRAM_SIZE>,
-    /// Public defines.
-    pub public_defines: PublicDefines,
 }
 
 #[test]

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -32,7 +32,7 @@ pub fn pio(item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(item as PioMacroArgs);
     let result =
         match pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.source.value()) {
-            Ok(pio_parser::Program {
+            Ok(pio::ProgramWithDefines {
                 program,
                 public_defines,
             }) => {
@@ -95,7 +95,7 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #defines_struct
-                        ::pio_parser::Program {
+                        ::pio::ProgramWithDefines {
                             program: ::pio::Program::<{ #program_size }> {
                                 code: #code,
                                 origin: #origin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,6 +777,14 @@ impl<const PROGRAM_SIZE: usize> Program<PROGRAM_SIZE> {
     }
 }
 
+/// Parsed program with defines.
+pub struct ProgramWithDefines<PublicDefines, const PROGRAM_SIZE: usize> {
+    /// The compiled program.
+    pub program: Program<PROGRAM_SIZE>,
+    /// Public defines.
+    pub public_defines: PublicDefines,
+}
+
 #[test]
 fn test_jump_1() {
     let mut a = Assembler::<32>::new();


### PR DESCRIPTION
Currently, pio_proc::pio!() returns a pio_parser::Program, but pio-parser
is not no-std. This commit moves pio_parser::Program to
pio::ProgramWithDefines.

_This is probably the best way to fix this issue, although I do not know whether that's the best name for the type._