### PR TITLE
Give all packages an rp- prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pio"
+name = "rp-pio"
 version = "0.1.0"
 authors = ["snek"]
 edition = "2018"
@@ -16,5 +16,5 @@ num_enum = { version = "0.5", default_features = false }
 [dev-dependencies]
 test-generator = "0.3.0"
 pretty_assertions = "0.6"
-pio-proc = { path = "./pio-proc" }
-pio-parser = { path = "./pio-parser" }
+rp-pio-proc = { path = "./pio-proc" }
+rp-pio-parser = { path = "./pio-parser" }

--- a/pio-parser/Cargo.toml
+++ b/pio-parser/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pio-parser"
+name = "rp-pio-parser"
 version = "0.1.0"
 authors = ["snek"]
 edition = "2018"
@@ -7,7 +7,7 @@ resolver= "2"
 
 [dependencies]
 lalrpop-util = { version = "0.19.6", features = ["lexer"] }
-pio = { path = ".." }
+rp-pio = { path = ".."}
 
 [build-dependencies]
 lalrpop = "0.19.6"

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unusual_byte_groupings)]
 #![allow(clippy::upper_case_acronyms)]
 
-use pio::{
+use rp_pio::{
     InSource, Instruction, InstructionOperands, JmpCondition, MovDestination, MovOperation,
     MovSource, OutDestination, ProgramWithDefines, SetDestination, WaitSource,
 };
@@ -341,7 +341,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
             }
         }
 
-        let mut a = pio::Assembler::new_with_side_set(pio::SideSet::new(
+        let mut a = rp_pio::Assembler::new_with_side_set(rp_pio::SideSet::new(
             side_set_opt,
             side_set_size,
             side_set_pindirs,
@@ -358,7 +358,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
         let program = a.assemble_program().set_origin(origin);
 
         let program = match (wrap, wrap_target) {
-            (Some(wrap_source), Some(wrap_target)) => program.set_wrap(pio::Wrap {
+            (Some(wrap_source), Some(wrap_target)) => program.set_wrap(rp_pio::Wrap {
                 source: wrap_source,
                 target: wrap_target,
             }),
@@ -377,7 +377,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
 
 #[test]
 fn test() {
-    let p = Program::parse_program(
+    let p = rp_pio::Program::parse_program(
         "
     label:
       pull
@@ -402,7 +402,7 @@ fn test() {
 
 #[test]
 fn test_side_set() {
-    let p = Program::parse_program(
+    let p = rp_pio::Program::parse_program(
         "
     .side_set 1 opt
     .origin 5

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -1,7 +1,7 @@
 // https://github.com/raspberrypi/pico-sdk/blob/master/tools/pioasm/parser.yy
 
 use std::str::FromStr;
-use ::pio::{
+use ::rp_pio::{
   JmpCondition,
   WaitSource,
   InSource,

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pio-proc"
+name = "rp-pio-proc"
 version = "0.1.0"
 authors = ["snek"]
 edition = "2018"
@@ -13,6 +13,6 @@ syn = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
 codespan-reporting = "0.11"
-pio = { path = ".." }
-pio-parser = { path = "../pio-parser" }
+rp-pio = { path = ".." }
+rp-pio-parser = { path = "../pio-parser"}
 lalrpop-util = "0.19.6"

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -31,8 +31,8 @@ impl syn::parse::Parse for PioMacroArgs {
 pub fn pio(item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(item as PioMacroArgs);
     let result =
-        match pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.source.value()) {
-            Ok(pio::ProgramWithDefines {
+        match rp_pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.source.value()) {
+            Ok(rp_pio::ProgramWithDefines {
                 program,
                 public_defines,
             }) => {
@@ -50,13 +50,13 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 .parse()
                 .unwrap();
                 let wrap: proc_macro2::TokenStream = format!(
-                    "::pio::Wrap {{source: {}, target: {}}}",
+                    "::rp_pio::Wrap {{source: {}, target: {}}}",
                     program.wrap.source, program.wrap.target
                 )
                 .parse()
                 .unwrap();
                 let side_set: proc_macro2::TokenStream = format!(
-                    "::pio::SideSet::new_from_proc_macro({}, {}, {})",
+                    "::rp_pio::SideSet::new_from_proc_macro({}, {}, {})",
                     program.side_set.optional(),
                     program.side_set.bits(),
                     program.side_set.pindirs()
@@ -95,8 +95,8 @@ pub fn pio(item: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #defines_struct
-                        ::pio::ProgramWithDefines {
-                            program: ::pio::Program::<{ #program_size }> {
+                        ::rp_pio::ProgramWithDefines {
+                            program: ::rp_pio::Program::<{ #program_size }> {
                                 code: #code,
                                 origin: #origin,
                                 wrap: #wrap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,29 +5,29 @@
 //! // the FIFO is empty. Write the least significant bit to the OUT pin
 //! // group.
 //! // https://github.com/raspberrypi/pico-examples/tree/master/pio/hello_pio/hello.pio
-//! let mut a = pio::Assembler::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::new();
+//! let mut a = rp_pio::Assembler::<{ rp_pio::RP2040_MAX_PROGRAM_SIZE }>::new();
 //!
 //! let mut loop_label = a.label();
 //!
 //! a.bind(&mut loop_label);
 //! a.pull(false, false);
-//! a.out(pio::OutDestination::PINS, 1);
-//! a.jmp(pio::JmpCondition::Always, &mut loop_label);
+//! a.out(rp_pio::OutDestination::PINS, 1);
+//! a.jmp(rp_pio::JmpCondition::Always, &mut loop_label);
 //!
 //! let program = a.assemble_program();
 //! ```
 //!
 //! ## Wrapping
 //! ```rust
-//! let mut a = pio::Assembler::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::new();
+//! let mut a = rp_pio::Assembler::<{ rp_pio::RP2040_MAX_PROGRAM_SIZE }>::new();
 //!
 //! let mut wrap_source = a.label();
 //! let mut wrap_target = a.label();
 //!
 //! // Initialize pin direction only once
-//! a.set(pio::SetDestination::PINDIRS, 1);
+//! a.set(rp_pio::SetDestination::PINDIRS, 1);
 //! a.bind(&mut wrap_target);
-//! a.out(pio::OutDestination::PINS, 1);
+//! a.out(rp_pio::OutDestination::PINS, 1);
 //! a.bind(&mut wrap_source);
 //!
 //! let program = a.assemble_with_wrap(wrap_source, wrap_target);

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -6,7 +6,7 @@ fn test(test: &str) {
     let path = std::path::PathBuf::from(test);
     let program_source = std::fs::read_to_string(&path).unwrap();
     let programs =
-        pio_parser::Parser::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::parse_file(&program_source)
+        rp_pio_parser::Parser::<{ rp_pio::RP2040_MAX_PROGRAM_SIZE }>::parse_file(&program_source)
             .unwrap();
 
     let mut hex_path = path;

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test_pio_proc() {
-    let p = pio_proc::pio!(
+    let p = rp_pio_proc::pio!(
         1,
         "
     label:
@@ -11,7 +11,7 @@ fn test_pio_proc() {
     assert_eq!(&*p.program.code, &[0u16]);
     assert_eq!(
         p.program.wrap,
-        pio::Wrap {
+        rp_pio::Wrap {
             source: 0,
             target: 0
         }
@@ -20,7 +20,7 @@ fn test_pio_proc() {
 
 #[test]
 fn test_pio_proc2() {
-    let p = pio_proc::pio!(
+    let p = rp_pio_proc::pio!(
         32,
         "
     .origin 5
@@ -36,7 +36,7 @@ fn test_pio_proc2() {
     assert_eq!(&*p.program.code, &[0, 0]);
     assert_eq!(
         p.program.wrap,
-        pio::Wrap {
+        rp_pio::Wrap {
             source: 0,
             target: 0
         }
@@ -48,12 +48,12 @@ fn test_pio_proc2() {
 #[test]
 fn test_pio_proc_size() {
     // Inline constant size
-    pio_proc::pio!(32, "label:\njmp label\n");
+    rp_pio_proc::pio!(32, "label:\njmp label\n");
     // Constant variable
     const PROGRAM_SIZE: usize = 32;
-    pio_proc::pio!(PROGRAM_SIZE, "label:\njmp label\n");
+    rp_pio_proc::pio!(PROGRAM_SIZE, "label:\njmp label\n");
     // Expression
-    pio_proc::pio!(10 + 20, "label:\njmp label\n");
+    rp_pio_proc::pio!(10 + 20, "label:\njmp label\n");
     // Constant from another crate
-    pio_proc::pio!(pio::RP2040_MAX_PROGRAM_SIZE, "label:\njmp label\n");
+    rp_pio_proc::pio!(rp_pio::RP2040_MAX_PROGRAM_SIZE, "label:\njmp label\n");
 }


### PR DESCRIPTION
The crate name pio is already taken, so we can't publish this crate with the current name unless we ask the owner of pio to transfer ownership.
It might be nice to have a common prefix on crates inside rp-rs anyway, so I thought I'd check what a rename would look like.

As an alternative solution, we could also do tricks like
```
pio = { path = "..", package = "rp-pio" }
```
to keep things the names of everything the same. I couldn't keep the tests passing when doing this, however, hence the giant find+replace solution.