### PR TITLE
Constify SideSet::new and add a convenience method for a nop instruction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,11 +605,11 @@ impl<const PROGRAM_SIZE: usize> Assembler<PROGRAM_SIZE> {
 }
 
 macro_rules! instr_impl {
-    ( $(#[$inner:ident $($args:tt)*])* $name:ident ( $self:ident, $( $arg_name:ident : $arg_ty:ty ),* ) $body:expr, $delay:expr, $side_set:expr ) => {
+    ( $(#[$inner:ident $($args:tt)*])* $name:ident ( $self:ident $(, $( $arg_name:ident : $arg_ty:ty ),*)? ) $body:expr, $delay:expr, $side_set:expr ) => {
         $(#[$inner $($args)*])*
         pub fn $name(
-            &mut $self,
-            $( $arg_name : $arg_ty , )*
+            &mut $self
+            $(, $( $arg_name : $arg_ty , )*)?
         ) {
             $self.instructions.push(Instruction {
                 operands: $body,
@@ -621,20 +621,12 @@ macro_rules! instr_impl {
 }
 
 macro_rules! instr {
-    ( $(#[$inner:ident $($args:tt)*])* $name:ident ( $self:ident ) $body:expr ) => {
-        instr_impl!($(#[$inner $($args)*])* $name ( $self, ) $body, 0, None );
+    ( $(#[$inner:ident $($args:tt)*])* $name:ident ( $self:ident $(, $($arg_name:ident : $arg_ty:ty ),*)? ) $body:expr ) => {
+        instr_impl!($(#[$inner $($args)*])* $name ( $self $(, $( $arg_name: $arg_ty ),*)? ) $body, 0, None );
         paste::paste! {
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay >] ( $self, delay: u8 ) $body, delay, None );
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_side_set >] ( $self, side_set: u8 ) $body, 0, Some(side_set) );
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay_and_side_set >] ( $self, delay: u8, side_set: u8 ) $body, delay, Some(side_set) );
-        }
-    };
-    ( $(#[$inner:ident $($args:tt)*])* $name:ident ( $self:ident, $( $arg_name:ident : $arg_ty:ty ),* ) $body:expr ) => {
-        instr_impl!($(#[$inner $($args)*])* $name ( $self, $( $arg_name: $arg_ty ),* ) $body, 0, None );
-        paste::paste! {
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay >] ( $self, $( $arg_name: $arg_ty ),* , delay: u8 ) $body, delay, None );
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_side_set >] ( $self, $( $arg_name: $arg_ty ),* , side_set: u8 ) $body, 0, Some(side_set) );
-            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay_and_side_set >] ( $self, $( $arg_name: $arg_ty ),* , delay: u8, side_set: u8 ) $body, delay, Some(side_set) );
+            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay >] ( $self $(, $( $arg_name: $arg_ty ),*)? , delay: u8 ) $body, delay, None );
+            instr_impl!($(#[$inner $($args)*])* [< $name _with_side_set >] ( $self $(, $( $arg_name: $arg_ty ),*)? , side_set: u8 ) $body, 0, Some(side_set) );
+            instr_impl!($(#[$inner $($args)*])* [< $name _with_delay_and_side_set >] ( $self $(, $( $arg_name: $arg_ty ),*)? , delay: u8, side_set: u8 ) $body, delay, Some(side_set) );
         }
     }
 }


### PR DESCRIPTION
The implementation of `nop` follows the [c-sdk](https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h#L171-L173).