### PR TITLE
Implement relative index for WAIT IRQ instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- None
+- Add optional `rel` flag to index on `WAIT IRQ` instruction. (Breaking change, adds parameter to public data structures)
 
 ## [0.1.0] [Crates.io](https://crates.io/crates/pio-rs/0.1.0) [Github](https://github.com/rp-rs/pio-rs/releases/tag/v0.1.0)
 

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -93,6 +93,7 @@ pub(crate) enum ParsedOperands<'input> {
         polarity: Value<'input>,
         source: WaitSource,
         index: Value<'input>,
+        relative: bool,
     },
     IN {
         source: InSource,
@@ -138,10 +139,12 @@ impl<'i> ParsedOperands<'i> {
                 polarity,
                 source,
                 index,
+                relative,
             } => InstructionOperands::WAIT {
                 polarity: polarity.reify(state) as u8,
                 source: *source,
                 index: index.reify(state) as u8,
+                relative: *relative,
             },
             ParsedOperands::IN { source, bit_count } => InstructionOperands::IN {
                 source: *source,

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -108,10 +108,11 @@ BaseInstruction: ParsedOperands<'input> = {
     },
     address: e,
   },
-  "wait" <p:Value> <s:WaitSource> ","? <i:Value> => ParsedOperands::WAIT {
+  "wait" <p:Value> <s:WaitSource> ","? <i:Value> <r:"rel"?> => ParsedOperands::WAIT {
     polarity: p,
     source: s,
     index: i,
+    relative: r.is_some(),
   },
   "in" <s:InSource> ","? <b:Value> => ParsedOperands::IN {
     source: s,


### PR DESCRIPTION
According to the [datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf#%5B%7B%22num%22%3A349%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C115%2C453.676%2Cnull%5D) (and actually tested on real hardware) the `wait <polarity> irq <irq_num>` instruction can have an optional `rel` flag.

This patch adds that flag. (Breaking change due to changes on public data structures)