### PR TITLE
Updated syntax to allow for files, changed old syntax to follow asm!()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- None
+- Updated syntax to allow for `.pio` files
+- Updated pio asm macro with new syntax to follow `asm!`
 
 ## [0.1.0] [Crates.io](https://crates.io/crates/pio-rs/0.1.0) [Github](https://github.com/rp-rs/pio-rs/releases/tag/v0.1.0)
 

--- a/README.md
+++ b/README.md
@@ -45,24 +45,35 @@ at compile time.
 Your `Cargo.toml` file should include:
 
 ```toml
-[dev-dependencies]
+[dependencies]
 pio-proc = "0.1"
+pio = "0.1"
 ```
 
-Your Rust program should contain your PIO program, as follows:
+Your Rust program should contain your PIO program, as follows with PIO asm directly in the file:
 
 ```rust
-use pio_proc::pio;
+use pio_proc::pio_asm;
 
-let program = pio_proc::pio!(
-    32,
-    "
-    set pindirs, 1
-    .wrap_target
-    set pins, 0 [31]
-    set pins, 1 [31]
-    .wrap
-    "
+let program = pio_proc::pio_asm!(
+    "set pindirs, 1",
+    ".wrap_target",
+    "set pins, 0 [31]",
+    "set pins, 1 [31]",
+    ".wrap",
+    options(max_program_size = 32) // Optional, defaults to 32
+);
+```
+
+Or you can assemble a stand-alone PIO file from disk:
+
+```rust
+use pio_proc::pio_file;
+
+let program = pio_proc::pio_file!(
+    "../tests/test.pio",
+    select_program("test"), // Optional if only one program in the file
+    options(max_program_size = 32) // Optional, defaults to 32
 );
 ```
 

--- a/pio-parser/Cargo.toml
+++ b/pio-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pio-parser"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["snek", "The rp-rs Developers"]
 edition = "2018"
 resolver= "2"

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -232,7 +232,7 @@ impl<'a> ProgramState<'a> {
     }
 }
 
-type ParseError<'input> = lalrpop_util::ParseError<usize, parser::Token<'input>, &'static str>;
+pub type ParseError<'input> = lalrpop_util::ParseError<usize, parser::Token<'input>, &'static str>;
 
 pub struct Parser<const PROGRAM_SIZE: usize>;
 
@@ -241,7 +241,8 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
     /// separated by `.program` directives.
     pub fn parse_file(
         source: &str,
-    ) -> Result<Vec<ProgramWithDefines<HashMap<String, i32>, PROGRAM_SIZE>>, ParseError> {
+    ) -> Result<HashMap<String, ProgramWithDefines<HashMap<String, i32>, PROGRAM_SIZE>>, ParseError>
+    {
         match parser::FileParser::new().parse(source) {
             Ok(f) => {
                 let mut state = FileState::default();
@@ -262,7 +263,13 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
                     }
                 }
 
-                Ok(f.1.iter().map(|p| Parser::process(p, &mut state)).collect())
+                Ok(f.1
+                    .iter()
+                    .map(|p| {
+                        let program_name = p.0.to_string();
+                        (program_name, Parser::process(&p.1, &mut state))
+                    })
+                    .collect())
             }
             Err(e) => Err(e),
         }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -34,7 +34,7 @@ match {
 // for parsing a .pio file
 pub(crate) File = NEWLINE* <DefineDirective*> <ProgramWithDirective*>;
 
-ProgramWithDirective = ".program" Symbol NEWLINE <Program>;
+ProgramWithDirective = ".program" <Symbol> NEWLINE <Program>;
 
 // for parsing macro input
 pub(crate) Program = NEWLINE* <Line*>;

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -12,8 +12,9 @@ description = "proc-macro for assembling PIO code in a Rust program at compile t
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
+proc-macro-error = "1.0"
+syn = "1.0"
 quote = "1.0"
 codespan-reporting = "0.11"
 pio = { path = "..", version = "0.1.0" }

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pio-proc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["snek", "The rp-rs Developers"]
 edition = "2018"
 resolver = "2"
@@ -18,5 +18,5 @@ syn = "1.0"
 quote = "1.0"
 codespan-reporting = "0.11"
 pio = { path = "..", version = "0.1.0" }
-pio-parser = { path = "../pio-parser", version = "0.1.0" }
+pio-parser = { path = "../pio-parser", version = "0.2.0" }
 lalrpop-util = "0.19.6"

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -1,8 +1,15 @@
-extern crate proc_macro;
 use lalrpop_util::ParseError;
 use proc_macro::TokenStream;
+use proc_macro2::Span;
+use proc_macro_error::{abort, abort_call_site, proc_macro_error};
 use quote::quote;
-use syn::parse_macro_input;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+use syn::{
+    parenthesized, parse, parse_macro_input, Expr, ExprLit, Ident, Lit, LitInt, LitStr, Token,
+};
 
 /// Maximum program size supported by the macro.
 ///
@@ -10,162 +17,435 @@ use syn::parse_macro_input;
 /// should be plenty for a while.
 const MAX_PROGRAM_SIZE: usize = 1024;
 
-struct PioMacroArgs {
-    program_size: syn::Expr,
-    _comma: syn::token::Comma,
-    source: syn::LitStr,
+struct OptionsArgs {
+    ident: Ident,
+    expr: Expr,
 }
 
-impl syn::parse::Parse for PioMacroArgs {
+impl syn::parse::Parse for OptionsArgs {
     fn parse(stream: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+        let ident = stream.parse()?;
+        let _equals: Token![=] = stream.parse()?;
+        let expr = stream.parse()?;
+
+        Ok(Self { ident, expr })
+    }
+}
+
+// Options are on the form Ident = Literal
+struct Options {
+    options: HashMap<String, (Ident, Expr)>,
+}
+
+impl Options {
+    fn validate(&self) -> Result<(), parse::Error> {
+        // NOTE: Add more options here in the future
+        let valid_identifiers = ["max_program_size"];
+
+        for (name, (id, _)) in &self.options {
+            if !valid_identifiers.contains(&name.as_str()) {
+                abort!(
+                    id,
+                    "unknown identifier, expected one of {:?}",
+                    valid_identifiers
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_max_program_size_or_default(&self) -> Result<Expr, parse::Error> {
+        if let Some(mps) = self.options.get("max_program_size") {
+            Ok(mps.1.clone())
+        } else {
+            Ok(Expr::Lit(ExprLit {
+                attrs: vec![],
+                lit: Lit::Int(LitInt::new("32", Span::call_site())),
+            }))
+        }
+    }
+}
+
+impl syn::parse::Parse for Options {
+    fn parse(stream: syn::parse::ParseStream) -> parse::Result<Self> {
+        // Parse the optional 'options'
+        let content;
+        parenthesized!(content in stream);
+
+        if !content.is_empty() {
+            let mut options = HashMap::new();
+
+            while !content.is_empty() {
+                let opt: OptionsArgs = content.parse()?;
+                options.insert(opt.ident.to_string(), (opt.ident, opt.expr));
+                let _trailing_comma: Option<Token![,]> = content.parse().ok();
+            }
+
+            let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+
+            let s = Self { options };
+
+            s.validate()?;
+
+            Ok(s)
+        } else {
+            Ok(Self {
+                options: HashMap::new(),
+            })
+        }
+    }
+}
+
+struct SelectProgram {
+    name: String,
+    ident: LitStr,
+}
+
+impl syn::parse::Parse for SelectProgram {
+    fn parse(stream: syn::parse::ParseStream) -> parse::Result<Self> {
+        // Parse the optional 'options'
+        let content;
+        parenthesized!(content in stream);
+
+        let name: LitStr = content.parse::<LitStr>()?;
+
         Ok(Self {
-            program_size: stream.parse()?,
-            _comma: stream.parse()?,
-            source: stream.parse()?,
+            name: name.value(),
+            ident: name,
         })
     }
 }
 
+struct PioFileMacroArgs {
+    max_program_size: Expr,
+    program: String,
+    program_name: Option<(String, LitStr)>,
+}
+
+impl syn::parse::Parse for PioFileMacroArgs {
+    fn parse(stream: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+        let mut program = String::new();
+
+        // Parse the list of instructions
+        if let Ok(s) = stream.parse::<LitStr>() {
+            let path = s.value();
+            let path = Path::new(&path);
+
+            let pathbuf = {
+                let mut p = PathBuf::new();
+
+                if path.is_relative() {
+                    p.push(env!("CARGO_MANIFEST_DIR"));
+                }
+
+                p.push(path);
+
+                p
+            };
+
+            if !pathbuf.exists() {
+                abort!(s, "the file '{}' does not exist", pathbuf.display());
+            }
+
+            match fs::read(pathbuf) {
+                Ok(content) => match std::str::from_utf8(&content) {
+                    Ok(prog) => program = prog.to_string(),
+                    Err(e) => {
+                        abort!(s, "could parse file: '{}'", e);
+                    }
+                },
+                Err(e) => {
+                    abort!(s, "could not read file: '{}'", e);
+                }
+            }
+
+            let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+        }
+
+        let mut select_program = None;
+        let mut options = Options {
+            options: HashMap::new(),
+        };
+
+        for _ in 0..2 {
+            if let Ok(ident) = stream.parse::<Ident>() {
+                match ident.to_string().as_str() {
+                    "select_program" => {
+                        // Parse the optional 'select_program'
+                        let sp: SelectProgram = stream.parse()?;
+                        select_program = Some(sp);
+                        let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+                    }
+                    "options" => {
+                        // Parse the optional 'options'
+                        let opt: Options = stream.parse()?;
+                        options = opt;
+                        let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+                    }
+                    _ => abort!(ident, "expected one of 'options' or 'select_program'"),
+                }
+            }
+        }
+
+        if !stream.is_empty() {
+            abort!(stream.span(), "expected end of input");
+        }
+
+        // Validate options
+        let max_program_size = options.get_max_program_size_or_default()?;
+
+        Ok(Self {
+            program_name: select_program.map(|v| (v.name, v.ident)),
+            max_program_size,
+            program,
+        })
+    }
+}
+
+struct PioAsmMacroArgs {
+    max_program_size: Expr,
+    program: String,
+}
+
+impl syn::parse::Parse for PioAsmMacroArgs {
+    fn parse(stream: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+        let mut program = String::new();
+
+        // Parse the list of instructions
+        while let Ok(s) = stream.parse::<LitStr>() {
+            writeln!(&mut program, "{}", s.value()).unwrap();
+
+            let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+        }
+
+        // Parse the optional 'options'
+
+        let mut options = Options {
+            options: HashMap::new(),
+        };
+
+        if let Ok(ident) = stream.parse::<Ident>() {
+            if ident == "options" {
+                let opt: Options = stream.parse()?;
+                options = opt;
+                let _trailing_comma: Option<Token![,]> = stream.parse().ok();
+            }
+        }
+
+        if !stream.is_empty() {
+            abort!(stream.span(), "expected end of input");
+        }
+
+        // Validate options
+        let max_program_size = options.get_max_program_size_or_default()?;
+
+        Ok(Self {
+            max_program_size,
+            program,
+        })
+    }
+}
+
+#[proc_macro]
+#[proc_macro_error]
+pub fn pio_file(item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(item as PioFileMacroArgs);
+    let parsed_programs = pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_file(&args.program);
+    let program = match &parsed_programs {
+        Ok(programs) => {
+            if let Some((program_name, ident)) = args.program_name {
+                if let Some(program) = programs.get(&program_name) {
+                    program
+                } else {
+                    abort! { ident, "program name not found in the provided file" }
+                }
+            } else {
+                // No name provided, check if there is only one in the map
+
+                match programs.len() {
+                    0 => abort_call_site! { "no programs in the provided file" },
+                    1 => programs.iter().next().unwrap().1,
+                    _ => {
+                        abort_call_site! { "more than 1 program in the provided file, select one using `select_program(\"my_program\")`" }
+                    }
+                }
+            }
+        }
+        Err(e) => return parse_error(e, &args.program).into(),
+    };
+
+    to_codegen(program, args.max_program_size).into()
+}
+
 /// A macro which invokes the PIO assembler at compile time.
 #[proc_macro]
-pub fn pio(item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(item as PioMacroArgs);
-    let result =
-        match pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.source.value()) {
-            Ok(pio::ProgramWithDefines {
-                program,
-                public_defines,
-            }) => {
-                let origin: proc_macro2::TokenStream =
-                    format!("{:?}", program.origin).parse().unwrap();
-                let code: proc_macro2::TokenStream = format!(
-                    "::core::iter::IntoIterator::into_iter([{}]).collect()",
-                    program
-                        .code
-                        .iter()
-                        .map(|v| v.to_string())
-                        .collect::<Vec<String>>()
-                        .join(",")
-                )
-                .parse()
-                .unwrap();
-                let wrap: proc_macro2::TokenStream = format!(
-                    "::pio::Wrap {{source: {}, target: {}}}",
-                    program.wrap.source, program.wrap.target
-                )
-                .parse()
-                .unwrap();
-                let side_set: proc_macro2::TokenStream = format!(
-                    "::pio::SideSet::new_from_proc_macro({}, {}, {})",
-                    program.side_set.optional(),
-                    program.side_set.bits(),
-                    program.side_set.pindirs()
-                )
-                .parse()
-                .unwrap();
-                let defines_struct: proc_macro2::TokenStream = format!(
-                    "
+#[proc_macro_error]
+pub fn pio_asm(item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(item as PioAsmMacroArgs);
+
+    let parsed_program = pio_parser::Parser::<{ MAX_PROGRAM_SIZE }>::parse_program(&args.program);
+
+    let program = match &parsed_program {
+        Ok(program) => program,
+        Err(e) => return parse_error(e, &args.program).into(),
+    };
+
+    to_codegen(program, args.max_program_size).into()
+}
+
+fn to_codegen(
+    program: &pio::ProgramWithDefines<HashMap<String, i32>, { MAX_PROGRAM_SIZE }>,
+    max_program_size: Expr,
+) -> proc_macro2::TokenStream {
+    let pio::ProgramWithDefines {
+        program,
+        public_defines,
+    } = program;
+    if let Expr::Lit(ExprLit {
+        attrs: _,
+        lit: Lit::Int(i),
+    }) = &max_program_size
+    {
+        if let Ok(mps) = i.base10_parse::<usize>() {
+            if program.code.len() > mps {
+                abort_call_site!(
+                    "the resulting program is larger than the maximum allowed: max = {}, size = {}",
+                    mps,
+                    program.code.len()
+                );
+            }
+        }
+    }
+
+    let origin: proc_macro2::TokenStream = format!("{:?}", program.origin).parse().unwrap();
+
+    let code: proc_macro2::TokenStream = format!(
+        "::core::iter::IntoIterator::into_iter([{}]).collect()",
+        program
+            .code
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<String>>()
+            .join(",")
+    )
+    .parse()
+    .unwrap();
+    let wrap: proc_macro2::TokenStream = format!(
+        "::pio::Wrap {{source: {}, target: {}}}",
+        program.wrap.source, program.wrap.target
+    )
+    .parse()
+    .unwrap();
+    let side_set: proc_macro2::TokenStream = format!(
+        "::pio::SideSet::new_from_proc_macro({}, {}, {})",
+        program.side_set.optional(),
+        program.side_set.bits(),
+        program.side_set.pindirs()
+    )
+    .parse()
+    .unwrap();
+    let defines_struct: proc_macro2::TokenStream = format!(
+        "
             struct ExpandedDefines {{
                 {}
             }}
             ",
-                    public_defines
-                        .keys()
-                        .map(|k| format!("{}: i32,", k))
-                        .collect::<Vec<String>>()
-                        .join("\n")
-                )
-                .parse()
-                .unwrap();
-                let defines_init: proc_macro2::TokenStream = format!(
-                    "
+        public_defines
+            .keys()
+            .map(|k| format!("{}: i32,", k))
+            .collect::<Vec<String>>()
+            .join("\n")
+    )
+    .parse()
+    .unwrap();
+    let defines_init: proc_macro2::TokenStream = format!(
+        "
             ExpandedDefines {{
                 {}
             }}
             ",
-                    public_defines
-                        .iter()
-                        .map(|(k, v)| format!("{}: {},", k, v))
-                        .collect::<Vec<String>>()
-                        .join("\n")
-                )
-                .parse()
-                .unwrap();
-                let program_size = args.program_size;
-                quote! {
-                    {
-                        #defines_struct
-                        ::pio::ProgramWithDefines {
-                            program: ::pio::Program::<{ #program_size }> {
-                                code: #code,
-                                origin: #origin,
-                                wrap: #wrap,
-                                side_set: #side_set,
-                            },
-                            public_defines: #defines_init,
-                        }
-                    }
-                }
+        public_defines
+            .iter()
+            .map(|(k, v)| format!("{}: {},", k, v))
+            .collect::<Vec<String>>()
+            .join("\n")
+    )
+    .parse()
+    .unwrap();
+    let program_size = max_program_size;
+    quote! {
+        {
+            #defines_struct
+            ::pio::ProgramWithDefines {
+                program: ::pio::Program::<{ #program_size }> {
+                    code: #code,
+                    origin: #origin,
+                    wrap: #wrap,
+                    side_set: #side_set,
+                },
+                public_defines: #defines_init,
             }
-            Err(e) => {
-                let files =
-                    codespan_reporting::files::SimpleFile::new("source", args.source.value());
+        }
+    }
+}
 
-                let (loc, messages) = match e {
-                    ParseError::InvalidToken { location } => {
-                        (location..location, vec!["invalid token".to_string()])
-                    }
-                    ParseError::UnrecognizedEOF { location, expected } => (
-                        location..location,
-                        vec![
-                            "unrecognized eof".to_string(),
-                            format!("expected one of {}", expected.join(", ")),
-                        ],
-                    ),
-                    ParseError::UnrecognizedToken { token, expected } => (
-                        token.0..token.2,
-                        vec![
-                            format!("unexpected token: {:?}", format!("{}", token.1)),
-                            format!("expected one of {}", expected.join(", ")),
-                        ],
-                    ),
-                    ParseError::ExtraToken { token } => {
-                        (token.0..token.2, vec![format!("extra token: {}", token.1)])
-                    }
-                    ParseError::User { error } => (0..0, vec![error.to_string()]),
-                };
+fn parse_error(error: &pio_parser::ParseError, program_source: &str) -> proc_macro2::TokenStream {
+    let e = error;
+    let files = codespan_reporting::files::SimpleFile::new("source", program_source);
 
-                let diagnostic = codespan_reporting::diagnostic::Diagnostic::error()
-                    .with_message(messages[0].clone())
-                    .with_labels(
-                        messages
-                            .iter()
-                            .enumerate()
-                            .map(|(i, m)| {
-                                codespan_reporting::diagnostic::Label::new(
-                                    if i == 0 {
-                                        codespan_reporting::diagnostic::LabelStyle::Primary
-                                    } else {
-                                        codespan_reporting::diagnostic::LabelStyle::Secondary
-                                    },
-                                    (),
-                                    loc.clone(),
-                                )
-                                .with_message(m)
-                            })
-                            .collect(),
-                    );
+    let (loc, messages) = match e {
+        ParseError::InvalidToken { location } => {
+            (*location..*location, vec!["invalid token".to_string()])
+        }
+        ParseError::UnrecognizedEOF { location, expected } => (
+            *location..*location,
+            vec![
+                "unrecognized eof".to_string(),
+                format!("expected one of {}", expected.join(", ")),
+            ],
+        ),
+        ParseError::UnrecognizedToken { token, expected } => (
+            token.0..token.2,
+            vec![
+                format!("unexpected token: {:?}", format!("{}", token.1)),
+                format!("expected one of {}", expected.join(", ")),
+            ],
+        ),
+        ParseError::ExtraToken { token } => {
+            (token.0..token.2, vec![format!("extra token: {}", token.1)])
+        }
+        ParseError::User { error } => (0..0, vec![error.to_string()]),
+    };
 
-                let mut writer = codespan_reporting::term::termcolor::Buffer::ansi();
-                let config = codespan_reporting::term::Config::default();
-                codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic).unwrap();
-                let data = writer.into_inner();
-                let data = std::str::from_utf8(&data).unwrap();
+    let diagnostic = codespan_reporting::diagnostic::Diagnostic::error()
+        .with_message(messages[0].clone())
+        .with_labels(
+            messages
+                .iter()
+                .enumerate()
+                .map(|(i, m)| {
+                    codespan_reporting::diagnostic::Label::new(
+                        if i == 0 {
+                            codespan_reporting::diagnostic::LabelStyle::Primary
+                        } else {
+                            codespan_reporting::diagnostic::LabelStyle::Secondary
+                        },
+                        (),
+                        loc.clone(),
+                    )
+                    .with_message(m)
+                })
+                .collect(),
+        );
 
-                quote! {
-                    compile_error!(#data)
-                }
-            }
-        };
-    TokenStream::from(result)
+    let mut writer = codespan_reporting::term::termcolor::Buffer::ansi();
+    let config = codespan_reporting::term::Config::default();
+    codespan_reporting::term::emit(&mut writer, &config, &files, &diagnostic).unwrap();
+    let data = writer.into_inner();
+    let data = std::str::from_utf8(&data).unwrap();
+
+    quote! {
+        compile_error!(#data)
+    }
 }

--- a/tests/pico-examples.rs
+++ b/tests/pico-examples.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+use std::{collections::HashMap, fs, path::PathBuf};
+
 #[test_generator::test_resources("tests/pico-examples/*.pio")]
 fn test(test: &str) {
-    let path = std::path::PathBuf::from(test);
-    let program_source = std::fs::read_to_string(&path).unwrap();
+    let path = PathBuf::from(test);
+    let program_source = fs::read_to_string(&path).unwrap();
     let programs =
         pio_parser::Parser::<{ pio::RP2040_MAX_PROGRAM_SIZE }>::parse_file(&program_source)
             .unwrap();
@@ -12,21 +14,25 @@ fn test(test: &str) {
     let mut hex_path = path;
     hex_path.set_extension("hex");
 
-    if let Ok(hex_source) = std::fs::read_to_string(hex_path) {
-        let mut hex_programs = vec![];
+    if let Ok(hex_source) = fs::read_to_string(hex_path) {
+        let mut hex_programs = HashMap::new();
+        let mut current_program = String::new();
+
         for line in hex_source.lines() {
-            if line.starts_with(".program") {
-                hex_programs.push(vec![]);
+            if let Some(new_program) = line.strip_prefix(".program ") {
+                current_program = new_program.into();
+                hex_programs.insert(current_program.clone(), vec![]);
             } else {
                 hex_programs
-                    .last_mut()
+                    .get_mut(&current_program)
                     .unwrap()
                     .push(u16::from_str_radix(line, 16).unwrap());
             }
         }
 
-        for (i, h) in hex_programs.iter().enumerate() {
-            assert_eq!(&*programs[i].program.code, h);
+        for (name, prog) in hex_programs.iter() {
+            let program = programs.get(name).unwrap();
+            assert_eq!(&*program.program.code, prog);
         }
     }
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -1,12 +1,27 @@
 #[test]
-fn test_pio_proc() {
-    let p = pio_proc::pio!(
-        1,
-        "
-    label:
-        jmp label
-    "
+fn test_file() {
+    let p = pio_proc::pio_file!(
+        "../tests/test.pio",
+        select_program("test2"),
+        options(max_program_size = 32)
     );
+    assert_eq!(p.program.origin, Some(5));
+    assert_eq!(&*p.program.code, &[0, 0]);
+    assert_eq!(
+        p.program.wrap,
+        pio::Wrap {
+            source: 0,
+            target: 0
+        }
+    );
+    assert_eq!(p.public_defines.label, 0);
+    assert_eq!(p.public_defines.owo, 2);
+}
+// }
+
+#[test]
+fn test_pio_proc() {
+    let p = pio_proc::pio_asm!("label:", "jmp label", options(max_program_size = 1));
     assert_eq!(p.program.origin, None);
     assert_eq!(&*p.program.code, &[0u16]);
     assert_eq!(
@@ -20,17 +35,15 @@ fn test_pio_proc() {
 
 #[test]
 fn test_pio_proc2() {
-    let p = pio_proc::pio!(
-        32,
-        "
-    .origin 5
-    public label:
-        .wrap_target
-        jmp label
-        .wrap
-        jmp label
-    .define public owo label + 2
-    "
+    let p = pio_proc::pio_asm!(
+        ".origin 5",
+        "public label:",
+        "    .wrap_target",
+        "    jmp label",
+        "    .wrap",
+        "    jmp label",
+        ".define public owo label + 2",
+        options(max_program_size = 32)
     );
     assert_eq!(p.program.origin, Some(5));
     assert_eq!(&*p.program.code, &[0, 0]);
@@ -48,12 +61,23 @@ fn test_pio_proc2() {
 #[test]
 fn test_pio_proc_size() {
     // Inline constant size
-    pio_proc::pio!(32, "label:\njmp label\n");
+    pio_proc::pio_asm!("label:", "jmp label", options(max_program_size = 32));
+
     // Constant variable
     const PROGRAM_SIZE: usize = 32;
-    pio_proc::pio!(PROGRAM_SIZE, "label:\njmp label\n");
+    pio_proc::pio_asm!(
+        "label:",
+        "jmp label",
+        options(max_program_size = PROGRAM_SIZE)
+    );
+
     // Expression
-    pio_proc::pio!(10 + 20, "label:\njmp label\n");
+    pio_proc::pio_asm!("label:", "jmp label", options(max_program_size = 10 + 20));
+
     // Constant from another crate
-    pio_proc::pio!(pio::RP2040_MAX_PROGRAM_SIZE, "label:\njmp label\n");
+    pio_proc::pio_asm!(
+        "label:",
+        "jmp label",
+        options(max_program_size = pio::RP2040_MAX_PROGRAM_SIZE)
+    );
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -17,7 +17,6 @@ fn test_file() {
     assert_eq!(p.public_defines.label, 0);
     assert_eq!(p.public_defines.owo, 2);
 }
-// }
 
 #[test]
 fn test_pio_proc() {

--- a/tests/test.pio
+++ b/tests/test.pio
@@ -1,0 +1,19 @@
+.program test
+
+.origin 5
+public label:
+    .wrap_target
+    jmp label
+    .wrap
+    jmp label
+.define public owo label + 2
+
+.program test2
+
+.origin 5
+public label:
+    .wrap_target
+    jmp label
+    .wrap
+    jmp label
+.define public owo label + 2


### PR DESCRIPTION
I have renamed the old proc-macro and refactored the parsing code.
The `options` is prepared for future extension if needed.

Now there are 2 syntaxes:

1. `asm!` like:

```rust
use pio_proc::pio_asm;

let program = pio_proc::pio_asm!(
    "set pindirs, 1",
    ".wrap_target",
    "set pins, 0 [31]",
    "set pins, 1 [31]",
    ".wrap",
    options(max_program_size = 32) // <- optional
);
```

or

```rust
use pio_proc::pio_asm;

let program = pio_proc::pio_asm!("
     set pindirs, 1
     .wrap_target
     set pins, 0 [31]
     set pins, 1 [31]
     .wrap
    ",
    options(max_program_size = 32) // <- optional
);
```

2. or a file on disk:

```rust
use pio_proc::pio_file;

let program = pio_proc::pio_file!(
    "./src/yolo.pio",
    select_program("my_program_name"), // <- optional if only one program in the file
    options(max_program_size = 32) // <- optional
);
```
 