### PR TITLE
Fixed relative paths for `pio_file!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed the search path for `pio_file` when using relative paths
+
 ## [0.2.0] [Crates.io](https://crates.io/crates/pio-rs/0.2.0) [Github](https://github.com/rp-rs/pio-rs/releases/tag/v0.2.0)
 
 - Updated syntax to allow for `.pio` files
@@ -17,5 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release
 
-[Unreleased]: https://github.com/rp-rs/pio-rs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/pio-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/pio-rs/tag/v0.2.0
 [0.1.0]: https://github.com/rp-rs/pio-rs/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Or you can assemble a stand-alone PIO file from disk:
 use pio_proc::pio_file;
 
 let program = pio_proc::pio_file!(
-    "../tests/test.pio",
+    "./tests/test.pio",
     select_program("test"), // Optional if only one program in the file
     options(max_program_size = 32) // Optional, defaults to 32
 );

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pio-proc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["snek", "The rp-rs Developers"]
 edition = "2018"
 resolver = "2"

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -136,7 +136,11 @@ impl syn::parse::Parse for PioFileMacroArgs {
                 let mut p = PathBuf::new();
 
                 if path.is_relative() {
-                    p.push(env!("CARGO_MANIFEST_DIR"));
+                    if let Some(crate_dir) = std::env::var_os("CARGO_MANIFEST_DIR") {
+                        p.push(crate_dir);
+                    } else {
+                        abort!(s, "Cannot find 'CARGO_MANIFEST_DIR' environment variable");
+                    }
                 }
 
                 p.push(path);

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_file() {
     let p = pio_proc::pio_file!(
-        "../tests/test.pio",
+        "./tests/test.pio",
         select_program("test2"),
         options(max_program_size = 32)
     );


### PR DESCRIPTION
There was an error where the compile time environment variable was pulled, instead of the runtime one - causing relative paths for `pio_file!` to be broken.

This PR fixes this issue.