### PR TITLE
Fix global directive newlines error

### DIFF
--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -257,7 +257,7 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
                         public,
                         name,
                         value,
-                    } = d
+                    } = d.0
                     {
                         fake_prog_state
                             .file_state

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -32,7 +32,7 @@ match {
 }
 
 // for parsing a .pio file
-pub(crate) File = NEWLINE* <DefineDirective*> <ProgramWithDirective*>;
+pub(crate) File = NEWLINE* <(DefineDirective NEWLINE+)*> <ProgramWithDirective*>;
 
 ProgramWithDirective = ".program" <Symbol> NEWLINE <Program>;
 

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -5,6 +5,13 @@ fn test_file() {
         select_program("test2"),
         options(max_program_size = 32)
     );
+    let p2 = pio_proc::pio_file!(
+        "./tests/test.pio",
+        select_program("test"),
+        options(max_program_size = 32)
+    );
+    assert_eq!(p.public_defines.foo, 3);
+    assert_eq!(p2.public_defines.foo, 3);
     assert_eq!(p.program.origin, Some(5));
     assert_eq!(&*p.program.code, &[0, 0]);
     assert_eq!(

--- a/tests/test.pio
+++ b/tests/test.pio
@@ -1,3 +1,5 @@
+.define public foo 3
+
 .program test
 
 .origin 5


### PR DESCRIPTION
Fixes the global define directive issue described in #24. I'm not familiar with `lalrpop`, if there's a better way if fixing this I'm happy to make changes.