### PR TITLE
Update the dependency versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Your `Cargo.toml` file should include:
 
 ```toml
 [dependencies]
-pio-proc = "0.1"
-pio = "0.1"
+pio-proc = "0.2"
+pio = "0.2"
 ```
 
 Your Rust program should contain your PIO program, as follows with PIO asm directly in the file:


### PR DESCRIPTION
I followed the instructions in the README while setting this crate up and realized that that things didn't work because of the outdated dependencies. This PR bumps the crate versions in the README.