### PR TITLE
Use (rel)ative bit only for IRQ WaitSource.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ impl InstructionOperands {
                     polarity << 2 | (*source as u8),
                     *index | (if *relative { 0b10000 } else { 0 }),
                 )
-            },
+            }
             InstructionOperands::IN { source, bit_count } => (*source as u8, *bit_count),
             InstructionOperands::OUT {
                 destination,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub enum JmpCondition {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq)]
+#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq, Eq)]
 pub enum WaitSource {
     GPIO = 0b00,
     PIN = 0b01,
@@ -221,10 +221,15 @@ impl InstructionOperands {
                 source,
                 index,
                 relative,
-            } => (
-                polarity << 2 | (*source as u8),
-                *index | (if *relative && *source == WaitSource::IRQ { 0b10000 } else { 0 }),
-            ),
+            } => {
+                if *relative && *source != WaitSource::IRQ {
+                    panic!("relative flag should only be used with WaitSource::IRQ");
+                }
+                (
+                    polarity << 2 | (*source as u8),
+                    *index | (if *relative { 0b10000 } else { 0 }),
+                )
+            },
             InstructionOperands::IN { source, bit_count } => (*source as u8, *bit_count),
             InstructionOperands::OUT {
                 destination,
@@ -934,7 +939,14 @@ instr_test!(
     SideSet::new(false, 5, false)
 );
 instr_test!(wait(0, WaitSource::IRQ, 10, true), 0b001_00000_010_11010);
-instr_test!(wait(0, WaitSource::PIN, 10, true), 0b001_00000_001_01010);
+
+#[test]
+#[should_panic]
+fn test_wait_relative_not_used_on_irq() {
+    let mut a = Assembler::<32>::new();
+    a.wait(0, WaitSource::PIN, 10, true);
+    a.assemble_program();
+}
 
 instr_test!(r#in(InSource::Y, 10), 0b010_00000_010_01010);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub enum JmpCondition {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq)]
 pub enum WaitSource {
     GPIO = 0b00,
     PIN = 0b01,
@@ -223,7 +223,7 @@ impl InstructionOperands {
                 relative,
             } => (
                 polarity << 2 | (*source as u8),
-                *index | (if *relative { 0b10000 } else { 0 }),
+                *index | (if *relative && *source == WaitSource::IRQ { 0b10000 } else { 0 }),
             ),
             InstructionOperands::IN { source, bit_count } => (*source as u8, *bit_count),
             InstructionOperands::OUT {
@@ -934,6 +934,7 @@ instr_test!(
     SideSet::new(false, 5, false)
 );
 instr_test!(wait(0, WaitSource::IRQ, 10, true), 0b001_00000_010_11010);
+instr_test!(wait(0, WaitSource::PIN, 10, true), 0b001_00000_001_01010);
 
 instr_test!(r#in(InSource::Y, 10), 0b010_00000_010_01010);
 


### PR DESCRIPTION
See [rp2040-datasheet.pdf](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf) section **3.4.3. WAIT**, notably explanation in 3.4.3.3. Assembler Syntax.
If *rel* is present, set MSb of index to signal relative mode. This is only valid for IRQ WaitSource.
I.e. the *rel* flag should be ignored for other sources.