### PR TITLE
Support `//` comments in .pio files

### DIFF
--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -23,7 +23,7 @@ grammar();
 
 match {
   r"[\t\f\v ]" => {}, // ignore whitespace
-  r"(\r?\n)?;[^\n\r]*" => {}, // ignore `;` comments
+  r"(\r?\n)?(;|//)[^\n\r]*" => {}, // ignore `;` and `//` comments
   r"\r?\n" => NEWLINE,
   r"% c-sdk \{[^%]*%}" => {}, // ignore `% c-sdk { ... }`
   r"\.lang_opt [^\n\r]*" => LANG_OPT, // lex `.lang_opt` directives

--- a/tests/test.pio
+++ b/tests/test.pio
@@ -1,3 +1,6 @@
+// Example comment
+; Example comment
+
 .define public foo 3
 
 .program test


### PR DESCRIPTION
pioasm supports both `;` and `//` as comments so I added `//` for consistency with pioasm. pio-rs already supported `;` for comments.