### PR TITLE
Fix clippy warning

### DIFF
--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -339,11 +339,11 @@ impl<const PROGRAM_SIZE: usize> Parser<PROGRAM_SIZE> {
                         side_set_pindirs = *pindirs;
                     }
                     ParsedDirective::WrapTarget => {
-                        assert!(wrap_target == None);
+                        assert!(wrap_target.is_none());
                         wrap_target = Some(instr_index);
                     }
                     ParsedDirective::Wrap => {
-                        assert!(wrap == None);
+                        assert!(wrap.is_none());
                         wrap = Some(instr_index - 1);
                     }
                     _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,7 @@ impl SideSet {
     pub const fn new(opt: bool, bits: u8, pindirs: bool) -> SideSet {
         SideSet {
             opt,
-            bits: bits + if opt { 1 } else { 0 },
+            bits: bits + opt as u8,
             max: (1 << bits) - 1,
             pindirs,
         }


### PR DESCRIPTION
The old code caused this new clippy warning since rust 1.65.0, failing the CI build:

```
error: boolean to int conversion using if
   --> src/lib.rs:477:26
    |
477 |             bits: bits + if opt { 1 } else { 0 },
    |                          ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(opt)`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
    = note: `opt as u8` or `opt.into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if
```

The fix suggested by clippy, `u8::from(opt)`, doesn't work in const context:

```
error[E0015]: cannot call non-const fn `<u8 as core::convert::From<bool>>::from` in constant functions
   --> src/lib.rs:477:26
    |
477 |             bits: bits + u8::from(opt),
    |                          ^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants

For more information about this error, try `rustc --explain E0015`.
```

The alterantive, `opt as u8`, does work.