### PR TITLE
Prepare release of pio v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] [Crates.io](https://crates.io/crates/pio-rs/0.2.1) [Github](https://github.com/rp-rs/pio-rs/releases/tag/v0.2.1)
+
 - Fixed the search path for `pio_file` when using relative paths
 - Check that the irq specified in a wait command is valid
+- rename ParsedInstruction refiy method to reify
+- Fix global directive newlines error
+- Use (rel)ative bit for IRQ WaitSource
+- disambiguate the use of pio_proc macros vs pio::Assembler
+- Limit valid range if irqs for wait command
+- Enable constant encoding for InstructionOperands
+- Support `//` comments in .pio files
 
 ## [0.2.0] [Crates.io](https://crates.io/crates/pio-rs/0.2.0) [Github](https://github.com/rp-rs/pio-rs/releases/tag/v0.2.0)
 
@@ -20,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release
 
-[Unreleased]: https://github.com/rp-rs/pio-rs/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rp-rs/pio-rs/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/rp-rs/pio-rs/tag/v0.2.1
 [0.2.0]: https://github.com/rp-rs/pio-rs/tag/v0.2.0
 [0.1.0]: https://github.com/rp-rs/pio-rs/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pio"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["snek", "The rp-rs developers"]
 edition = "2018"
 resolver = "2"


### PR DESCRIPTION
`embassy-rp` already relies on unreleased improvements of pio-rs:
https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$3Gsau5kgE5x7RYj9g5sG094YO7rx8w6vQ7x77n3S3TU?via=matrix.org&via=grusbv.com&via=community.rs

To avoid the need for git dependencies, we should just do a new release. I didn't find a breaking change since v0.2.0, so we can call it v0.2.1. Would be good if somebody could verify this, though.