### PR TITLE
Work around regex incompatibility

### DIFF
--- a/pio-parser/Cargo.toml
+++ b/pio-parser/Cargo.toml
@@ -14,3 +14,6 @@ pio = { path = "..", version = "0.2.1" }
 
 [build-dependencies]
 lalrpop = "0.19.6"
+# This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
+# It should be removed once that workaround is no longer needed.
+regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -20,3 +20,6 @@ codespan-reporting = "0.11"
 pio = { path = "..", version = "0.2.0" }
 pio-parser = { path = "../pio-parser", version = "0.2.0" }
 lalrpop-util = "0.19.6"
+# This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
+# It should be removed once that workaround is no longer needed.
+regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }


### PR DESCRIPTION
Due to https://github.com/lalrpop/lalrpop/issues/750, an upgrade to regex >= 1.8.0 causes build failues because the unicode feature on regex-syntax is no longer enabled automatically.

Work around that issue by adding a (otherwise unnecessary) dependency on regex-syntax, enabling the unicode feature.