### PR TITLE
Case sensitivity fix

### DIFF
--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -61,6 +61,14 @@ match {
   r"(?i)IfEmpty" => "ifempty",
   r"(?i)side" => "side",
   r"(?i)osre" => "osre",
+  r"(?i)\.define" => ".define",
+  r"(?i)\.program" => ".program",
+  r"(?i)\.origin" => ".origin",
+  r"(?i)\.side_set" => ".side_set",
+  r"(?i)\.wrap_target" => ".wrap_target",
+  r"(?i)\.wrap" => ".wrap",
+  r"(?i)\.lang_opt" => ".lang_opt",
+  r"(?i)\.word" => ".word",
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -59,6 +59,7 @@ match {
   r"(?i)public" => "public",
   r"(?i)IfFull" => "iffull",
   r"(?i)IfEmpty" => "ifempty",
+  r"(?i)side" => "side",
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -58,7 +58,7 @@ match {
   r"(?i)clear" => "clear",
   r"(?i)public" => "public",
   r"(?i)IfFull" => "iffull",
-  
+  r"(?i)IfEmpty" => "ifempty",
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -57,6 +57,8 @@ match {
   r"(?i)nowait" => "nowait",
   r"(?i)clear" => "clear",
   r"(?i)public" => "public",
+  r"(?i)IfFull" => "iffull",
+  
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -60,6 +60,7 @@ match {
   r"(?i)IfFull" => "iffull",
   r"(?i)IfEmpty" => "ifempty",
   r"(?i)side" => "side",
+  r"(?i)osre" => "osre",
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -56,6 +56,7 @@ match {
   r"(?i)status" => "status",
   r"(?i)nowait" => "nowait",
   r"(?i)clear" => "clear",
+  r"(?i)public" => "public",
 } else {
   _
 }

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -27,6 +27,35 @@ match {
   r"\r?\n" => NEWLINE,
   r"% c-sdk \{[^%]*%}" => {}, // ignore `% c-sdk { ... }`
   r"\.lang_opt [^\n\r]*" => LANG_OPT, // lex `.lang_opt` directives
+
+  // As per the rp2040 datasheet,
+  // "instruction names, keywords and directives are case insensitive"
+  r"(?i)nop" => "nop",
+  r"(?i)jmp" => "jmp",
+  r"(?i)wait" => "wait",
+  r"(?i)in" => "in",
+  r"(?i)out" => "out",
+  r"(?i)push" => "push",
+  r"(?i)pull" => "pull",
+  r"(?i)mov" => "mov",
+  r"(?i)irq" => "irq",
+  r"(?i)set" => "set",
+  r"(?i)x" => "x",
+  r"(?i)y" => "y",
+  r"(?i)pins" => "pins",
+  r"(?i)pin" => "pin",
+  r"(?i)gpio" => "gpio",
+  r"(?i)null" => "null",
+  r"(?i)isr" => "isr",
+  r"(?i)osr" => "osr",
+  r"(?i)pc" => "pc",
+  r"(?i)exec" => "exec",
+  r"(?i)pindirs" => "pindirs",
+  r"(?i)block" => "block",
+  r"(?i)noblock" => "noblock",
+  r"(?i)status" => "status",
+  r"(?i)nowait" => "nowait",
+  r"(?i)clear" => "clear",
 } else {
   _
 }

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -20,6 +20,8 @@ public label:
     irq clear 1
     irq set 1
     set pindirs, 0
+    jmp !x label
+    jmp !osre label
 
 .program variable_case
 label:
@@ -43,6 +45,8 @@ label:
     IRQ CLEAR 1
     IRQ SET 1
     SET PINDIRS, 0
+    JMP !X label
+    JMP !OSRE label
 
 .program variable_case_side_ref
 .side_set 1

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -1,0 +1,41 @@
+.program case_reference
+label:
+    jmp label
+    jmp label
+    mov pins, isr
+    mov osr, x
+    wait 1 gpio 1 
+    nop
+    wait 1 pin 1
+    wait 1 irq 1
+    in null, 1
+    out pc, 1
+    push block
+    pull noblock
+    mov exec, status
+    irq wait 3
+    irq nowait 2
+    irq clear 1
+    irq set 1
+    set pindirs, 0
+
+.program variable_case
+label:
+    JMp label
+    JMP label
+    MOV PINS, ISR
+    MOV OSR, X
+    WAIT 1 GPIO 1 
+    NOP
+    WAIT 1 PIN 1
+    WAIT 1 IRQ 1
+    IN NULL, 1
+    OUT PC, 1
+    PUSH BLOCK
+    PULL NOBLOCK
+    MOV EXEC, STATUS
+    IRQ WAIT 3
+    IRQ NOWAIT 2
+    IRQ CLEAR 1
+    IRQ SET 1
+    SET PINDIRS, 0

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -1,5 +1,5 @@
 .program case_reference
-label:
+public label:
     jmp label
     jmp label
     mov pins, isr

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -11,6 +11,7 @@ public label:
     in null, 1
     out pc, 1
     push block
+    push iffull
     pull noblock
     mov exec, status
     irq wait 3
@@ -32,6 +33,7 @@ label:
     IN NULL, 1
     OUT PC, 1
     PUSH BLOCK
+    PUSH IfFull
     PULL NOBLOCK
     MOV EXEC, STATUS
     IRQ WAIT 3

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -1,9 +1,12 @@
+.DEFINE PUBLIC me_a_symbol 2
+
 .program case_reference
 public label:
     jmp label
     jmp label
     mov pins, isr
     mov osr, x
+.wrap_target
     wait 1 gpio 1 
     nop
     wait 1 pin 1
@@ -19,16 +22,18 @@ public label:
     irq nowait 2
     irq clear 1
     irq set 1
+.wrap
     set pindirs, 0
     jmp !x label
     jmp !osre label
 
 .program variable_case
-label:
+PUBLIC label:
     JMp label
     JMP label
     MOV PINS, ISR
     MOV OSR, X
+.WRAP_TARGET
     WAIT 1 GPIO 1 
     NOP
     WAIT 1 PIN 1
@@ -44,14 +49,17 @@ label:
     IRQ NOWAIT 2
     IRQ CLEAR 1
     IRQ SET 1
+.WRAP
     SET PINDIRS, 0
     JMP !X label
     JMP !OSRE label
 
 .program variable_case_side_ref
+.origin 5
 .side_set 1
     out pins 1 side 0
 
-.program variable_case_side
-.side_set 1
+.PROGRAM variable_case_side
+.ORIGIN 5
+.SIDE_SET 1
     out pins 1 SIDE 0

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -12,6 +12,7 @@ public label:
     out pc, 1
     push block
     push iffull
+    pull ifempty
     pull noblock
     mov exec, status
     irq wait 3
@@ -34,6 +35,7 @@ label:
     OUT PC, 1
     PUSH BLOCK
     PUSH IfFull
+    PULL IfEmpty
     PULL NOBLOCK
     MOV EXEC, STATUS
     IRQ WAIT 3

--- a/tests/case_test.pio
+++ b/tests/case_test.pio
@@ -43,3 +43,11 @@ label:
     IRQ CLEAR 1
     IRQ SET 1
     SET PINDIRS, 0
+
+.program variable_case_side_ref
+.side_set 1
+    out pins 1 side 0
+
+.program variable_case_side
+.side_set 1
+    out pins 1 SIDE 0

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -102,5 +102,18 @@ fn test_case() {
         options(max_program_size = 32)
     );
 
+    let p_test_side = pio_proc::pio_file!(
+        "./tests/case_test.pio",
+        select_program("variable_case_side_ref"),
+        options(max_program_size = 32)
+    );
+
+    let p_ref_side = pio_proc::pio_file!(
+        "./tests/case_test.pio",
+        select_program("variable_case_side"),
+        options(max_program_size = 32)
+    );
+
     assert_eq!(&*p_test.program.code, &*p_ref.program.code);
+    assert_eq!(&*p_test_side.program.code, &*p_ref_side.program.code);
 }

--- a/tests/proc.rs
+++ b/tests/proc.rs
@@ -87,3 +87,20 @@ fn test_pio_proc_size() {
         options(max_program_size = pio::RP2040_MAX_PROGRAM_SIZE)
     );
 }
+
+#[test]
+fn test_case() {
+    let p_test = pio_proc::pio_file!(
+        "./tests/case_test.pio",
+        select_program("variable_case"),
+        options(max_program_size = 32)
+    );
+
+    let p_ref = pio_proc::pio_file!(
+        "./tests/case_test.pio",
+        select_program("case_reference"),
+        options(max_program_size = 32)
+    );
+
+    assert_eq!(&*p_test.program.code, &*p_ref.program.code);
+}


### PR DESCRIPTION
Adds _most_ keywords into the match statement for allowing case insensitivity.
This is related to #49 

I was hoping that the regex expressions would allow for regex groups for some sort of wildcard match, but oh well.

It does not handle the "!OSRE" keyword case.