### PR TITLE
Call include_file! on loaded pio file

### DIFF
--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -287,7 +287,7 @@ pub fn pio_file(item: TokenStream) -> TokenStream {
     to_codegen(
         program,
         args.max_program_size,
-        args.file_path.into_os_string().into_string().ok(),
+        Some(args.file_path.into_os_string().into_string().expect("file path must be valid UTF-8")),
     )
     .into()
 }

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -287,7 +287,12 @@ pub fn pio_file(item: TokenStream) -> TokenStream {
     to_codegen(
         program,
         args.max_program_size,
-        Some(args.file_path.into_os_string().into_string().expect("file path must be valid UTF-8")),
+        Some(
+            args.file_path
+                .into_os_string()
+                .into_string()
+                .expect("file path must be valid UTF-8"),
+        ),
     )
     .into()
 }


### PR DESCRIPTION
This works around #53. A better fix, proc_macro::tracked_path::path, is unstable.

I did not yet make sure that the compiler optimizes the included bytes out. That should be done before merging.
(And any more elegant alternative solution would be more than welcome, of course!)