### PR TITLE
Add some allow(unused) attributes to fix the build pipeline

### DIFF
--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 
 mod parser {
     #![allow(clippy::all)]
+    #![allow(unused)]
     include!(concat!(env!("OUT_DIR"), "/pio.rs"));
 }
 
@@ -63,6 +64,7 @@ pub(crate) enum ParsedDirective<'input> {
     },
     WrapTarget,
     Wrap,
+    #[allow(unused)]
     LangOpt(&'input str),
 }
 


### PR DESCRIPTION
Example for a pipeline failing without these changes: https://github.com/rp-rs/pio-rs/actions/runs/8377230666/job/22944762584?pr=56