### PR TITLE
Check if argument of SET instructions is valid

### DIFF
--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -1,4 +1,5 @@
 // PIO instr grouping is 3/5/3/5
+#![allow(clippy::manual_range_contains)]
 #![allow(clippy::unusual_byte_groupings)]
 #![allow(clippy::upper_case_acronyms)]
 

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -189,7 +189,13 @@ impl<'i> ParsedOperands<'i> {
             },
             ParsedOperands::SET { destination, data } => InstructionOperands::SET {
                 destination: *destination,
-                data: data.reify(state) as u8,
+                data: {
+                    let arg = data.reify(state);
+                    if arg < 0 || arg > 0x1f {
+                        panic!("SET argument out of range: {}", arg);
+                    }
+                    arg as u8
+                },
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,12 @@ impl InstructionOperands {
                     *index | (if *relative { 0b10000 } else { 0 }),
                 )
             }
-            InstructionOperands::SET { destination, data } => (*destination as u8, *data),
+            InstructionOperands::SET { destination, data } => {
+                if *data > 0x1f {
+                    panic!("SET argument out of range");
+                }
+                (*destination as u8, *data)
+            }
         }
     }
 


### PR DESCRIPTION
In response to https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$3RzuJ-nmtaz_z1qPf3CiSzEfYGdSZ8F7Ru4skRZ_eN0?via=matrix.org&via=tchncs.de&via=mozilla.org where the poster was surprised that this doesn't work as expected:

```
        let prg = pio_proc::pio_asm!(
            "set x, 0x333",
            "mov isr, x",
            "mov rxfifo[0], isr",
        );
```