### PR TITLE
Update lalrpop to 0.21

### DIFF
--- a/pio-parser/Cargo.toml
+++ b/pio-parser/Cargo.toml
@@ -9,11 +9,8 @@ license = "MIT"
 repository = "https://github.com/rp-rs/pio-rs"
 
 [dependencies]
-lalrpop-util = { version = "0.19.6", features = ["lexer"] }
+lalrpop-util = { version = "0.21.0", features = ["lexer"] }
 pio = { path = "..", version = "0.2.1" }
 
 [build-dependencies]
-lalrpop = "0.19.6"
-# This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
-# It should be removed once that workaround is no longer needed.
-regex-syntax = { version = "0.6", default-features = false, features = ["unicode"] }
+lalrpop = "0.21.0"

--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -19,7 +19,4 @@ quote = "1.0"
 codespan-reporting = "0.11"
 pio = { path = "..", version = "0.2.0" }
 pio-parser = { path = "../pio-parser", version = "0.2.0" }
-lalrpop-util = "0.19.6"
-# This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
-# It should be removed once that workaround is no longer needed.
-regex-syntax = { version = "0.6", default-features = false, features = ["unicode"] }
+lalrpop-util = "0.21.0"

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -402,7 +402,7 @@ fn parse_error(error: &pio_parser::ParseError, program_source: &str) -> proc_mac
         ParseError::InvalidToken { location } => {
             (*location..*location, vec!["invalid token".to_string()])
         }
-        ParseError::UnrecognizedEOF { location, expected } => (
+        ParseError::UnrecognizedEof { location, expected } => (
             *location..*location,
             vec![
                 "unrecognized eof".to_string(),


### PR DESCRIPTION
The workaround with `regex-syntax` is no longer needed, if `lalrpop` is updated to the most recent version.