### PR TITLE
Replace `proc-macro-error` with `proc-macro-error2`

### DIFF
--- a/pio-proc/Cargo.toml
+++ b/pio-proc/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-proc-macro-error = "1.0"
-syn = "1.0"
+proc-macro-error2 = "2.0"
+syn = "2.0"
 quote = "1.0"
 codespan-reporting = "0.11"
 pio = { path = "..", version = "0.2.0" }

--- a/pio-proc/src/lib.rs
+++ b/pio-proc/src/lib.rs
@@ -1,7 +1,7 @@
 use lalrpop_util::ParseError;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use proc_macro_error::{abort, abort_call_site, proc_macro_error};
+use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use quote::quote;
 use std::collections::HashMap;
 use std::fmt::Write;


### PR DESCRIPTION
`proc-macro-error` depends on `syn` 1.0 and is [no longer maintained](https://vulert.com/vuln-db/crates-io-proc-macro-error-150139). This PR replaces it with the drop-in replacement [`proc-macro-error2`](https://crates.io/crates/proc-macro-error2).