### PR TITLE
Add required Cargo.toml fields to pio-core

### DIFF
--- a/pio-core/Cargo.toml
+++ b/pio-core/Cargo.toml
@@ -2,6 +2,9 @@
 name = "pio-core"
 version = "0.3.0"
 edition = "2021"
+license = "MIT"
+description = "Low-level internals for RP2040's PIO State Machines. You should use the pio crate instead."
+repository = "https://github.com/rp-rs/pio-rs"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }


### PR DESCRIPTION
pio-core was missing license, description, repository.
this is enough to make `cargo publish --dry-run` happy, hoping that's the last thing needed