### PR TITLE
Add IRQ prev/rel/next for wait instruction.

### DIFF
--- a/pio-core/src/lib.rs
+++ b/pio-core/src/lib.rs
@@ -160,7 +160,7 @@ pub enum InstructionOperands {
         polarity: u8,
         source: WaitSource,
         index: u8,
-        relative: bool,
+        index_mode: Option<IrqIndexMode>,
     },
     IN {
         source: InSource,
@@ -225,17 +225,24 @@ impl InstructionOperands {
                 polarity,
                 source,
                 index,
-                relative,
+                index_mode,
             } => {
-                if *relative && !matches!(*source, WaitSource::IRQ) {
-                    panic!("relative flag should only be used with WaitSource::IRQ");
+                if index_mode.is_some() && !matches!(*source, WaitSource::IRQ) {
+                    panic!("index_mode should only be used with WaitSource::IRQ");
                 }
                 if matches!(*source, WaitSource::IRQ) && *index > 7 {
                     panic!("Index for WaitSource::IRQ should be in range 0..=7");
                 }
                 (
                     ((*polarity) << 2) | (*source as u8),
-                    *index | (if *relative { 0b10000 } else { 0 }),
+                    *index | (
+                        match index_mode {
+                            Some(IrqIndexMode::DIRECT) | None => 0b00_000,
+                            Some(IrqIndexMode::PREV) => 0b01_000,
+                            Some(IrqIndexMode::REL) => 0b10_000,
+                            Some(IrqIndexMode::NEXT) => 0b11_000,
+                        }
+                    ),
                 )
             }
             InstructionOperands::IN { source, bit_count } => {
@@ -315,18 +322,22 @@ impl InstructionOperands {
                     address: o1,
                 }),
             0b001 => {
-                WaitSource::try_from(o0 & 0b011)
-                    .ok()
-                    .map(|source| InstructionOperands::WAIT {
-                        polarity: o0 >> 2,
-                        source,
-                        index: if source == WaitSource::IRQ {
-                            o1 & 0b00111
-                        } else {
-                            o1
-                        },
-                        relative: source == WaitSource::IRQ && (o1 & 0b10000) != 0,
-                    })
+                let source = WaitSource::try_from(o0 & 0b011).ok()?;
+                Some(InstructionOperands::WAIT {
+                    polarity: o0 >> 2,
+                    source,
+                    index: if source == WaitSource::IRQ {
+                        o1 & 0b00111
+                    } else {
+                        o1
+                    },
+                    index_mode: if source == WaitSource::IRQ {
+                        let index_mode = IrqIndexMode::try_from((o1 >> 3) & 0b11);
+                        Some(index_mode.ok()?)
+                    } else {
+                        None
+                    },
+                })
             }
             0b010 => InSource::try_from(o0)
                 .ok()
@@ -737,12 +748,12 @@ impl<const PROGRAM_SIZE: usize> Assembler<PROGRAM_SIZE> {
     instr!(
         /// Emit a `wait` instruction with `polarity` from `source` with `index` which may be
         /// `relative`.
-        wait(self, polarity: u8, source: WaitSource, index: u8, relative: bool) {
+        wait(self, polarity: u8, source: WaitSource, index: u8, index_mode: Option<IrqIndexMode>) {
             InstructionOperands::WAIT {
                 polarity,
                 source,
                 index,
-                relative,
+                index_mode,
             }
         }
     );
@@ -1031,42 +1042,52 @@ macro_rules! instr_test {
 }
 
 instr_test!(
-    wait(0, WaitSource::IRQ, 2, false),
+    wait(0, WaitSource::IRQ, 2, Some(IrqIndexMode::DIRECT)),
     0b001_00000_010_00010,
     PioVersion::V0
 );
 instr_test!(
-    wait(1, WaitSource::IRQ, 7, false),
+    wait(1, WaitSource::IRQ, 7, Some(IrqIndexMode::DIRECT)),
     0b001_00000_110_00111,
     PioVersion::V0
 );
 instr_test!(
-    wait(1, WaitSource::GPIO, 16, false),
+    wait(1, WaitSource::GPIO, 16, Some(IrqIndexMode::DIRECT)),
     0b001_00000_100_10000,
     PioVersion::V0
 );
 instr_test!(
-    wait_with_delay(0, WaitSource::IRQ, 2, false, 30),
+    wait_with_delay(0, WaitSource::IRQ, 2, Some(IrqIndexMode::DIRECT), 30),
     0b001_11110_010_00010,
     PioVersion::V0
 );
 instr_test!(
-    wait_with_side_set(0, WaitSource::IRQ, 2, false, 0b10101),
+    wait_with_side_set(0, WaitSource::IRQ, 2, Some(IrqIndexMode::DIRECT), 0b10101),
     0b001_10101_010_00010,
     SideSet::new(false, 5, false),
     PioVersion::V0
 );
 instr_test!(
-    wait(0, WaitSource::IRQ, 2, true),
+    wait(0, WaitSource::IRQ, 2, Some(IrqIndexMode::PREV)),
+    0b001_00000_010_01010,
+    PioVersion::V1
+);
+instr_test!(
+    wait(0, WaitSource::IRQ, 2, Some(IrqIndexMode::REL)),
     0b001_00000_010_10010,
     PioVersion::V0
+);
+instr_test!(
+    wait(0, WaitSource::IRQ, 2, Some(IrqIndexMode::NEXT)),
+    0b001_00000_010_11010,
+    PioVersion::V1
 );
 
 #[test]
 #[should_panic]
 fn test_wait_relative_not_used_on_irq() {
     let mut a = Assembler::<32>::new();
-    a.wait(0, WaitSource::PIN, 10, true);
+    a.wait(0, WaitSource::PIN, 10, Some(IrqIndexMode::REL));
     a.assemble_program();
 }
 
@@ -1166,7 +1187,7 @@ instr_test!(
 );
 
 instr_test!(
-    wait(0, WaitSource::JMPPIN, 0, false),
+    wait(0, WaitSource::JMPPIN, 0, None),
     0b001_00000_0110_0000,
     PioVersion::V1
 );

--- a/pio-parser/src/lib.rs
+++ b/pio-parser/src/lib.rs
@@ -181,7 +181,7 @@ pub(crate) enum ParsedOperands<'input> {
         polarity: Value<'input>,
         source: WaitSource,
         index: Value<'input>,
-        relative: bool,
+        index_mode: Option<IrqIndexMode>,
     },
     IN {
         source: InSource,
@@ -227,12 +227,12 @@ impl ParsedOperands<'_> {
                 polarity,
                 source,
                 index,
-                relative,
+                index_mode,
             } => InstructionOperands::WAIT {
                 polarity: polarity.reify(state) as u8,
                 source: *source,
                 index: index.reify(state) as u8,
-                relative: *relative,
+                index_mode: *index_mode,
             },
             ParsedOperands::IN { source, bit_count } => InstructionOperands::IN {
                 source: *source,

--- a/pio-parser/src/pio.lalrpop
+++ b/pio-parser/src/pio.lalrpop
@@ -153,11 +153,11 @@ BaseInstruction: ParsedOperands<'input> = {
     },
     address: e,
   },
-  "wait" <p:Value> <s:WaitSource> ","? <i:Value> <r:"rel"?> => ParsedOperands::WAIT {
+  "wait" <p:Value> <s:WaitSource> ","? <i:Value> <m:IrqIndexMode?> => ParsedOperands::WAIT {
     polarity: p,
     source: s,
     index: i,
-    relative: r.is_some(),
+    index_mode: m,
   },
   "in" <s:InSource> ","? <b:Value> => ParsedOperands::IN {
     source: s,


### PR DESCRIPTION
Starting with the RP2350, it is now possible to specify `00 (direct)`, `01 (prev)`, `10 (rel)`, and `11 (next)` even when irq is used as the source for the wait instruction. Since the current crate did not seem to support this yet, I have added this functionality.

To ensure a consistent and user-friendly experience even when a non-IRQ source is used, I implemented these options using the Option type. I would appreciate it if you could review whether this design aligns with the overall philosophy of the crate.